### PR TITLE
Fix vulnerability involving the requests package

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ pandas = "*"
 pint = "*"
 scipy = "*"
 onshapepy = "*"
+requests = ">=2.20.0"
 
 [dev-packages]
 codecov = "*"
@@ -18,6 +19,7 @@ Sphinx = "*"
 sphinx_rtd_theme = "==0.4.0"
 aguaclara = {editable = true, path = "."}
 pytest-runner = "*"
+requests = ">=2.20.0"
 
 [requires]
 python_version = "3.5"


### PR DESCRIPTION
GitHub has notified us of a vulnerability involving the `requests` package, as specified for `pipenv` use. I just added a few lines specifying the latest version.