### PR TITLE
Set initial Plant ent tank a_ratio to arbitrary number >1

### DIFF
--- a/aguaclara/design/floc.py
+++ b/aguaclara/design/floc.py
@@ -133,7 +133,7 @@ class Flocculator:
         :rtype: float * 1 / second
         """
         return ((con.GRAVITY * self.HL) /
-               (pc.nu(self.temp) * self.GT)).to(u.s ** -1)
+                (pc.nu(self.temp) * self.GT)).to(u.s ** -1)
 
     @property
     def retention_time(self):
@@ -275,10 +275,10 @@ class Flocculator:
         :returns: Minimum number of expansions/baffle space
         :rtype: int
         """
-        
+
         return ((self.BAFFLE_K /
-               (2 * self.expansion_h_max * (self.vel_grad_avg ** 2) * pc.nu(self.temp))) ** (1/3) *
-               self.q / ha.HUMAN_W_MIN).to(u.cm)
+                 (2 * self.expansion_h_max * (self.vel_grad_avg ** 2) * pc.nu(self.temp))) ** (1/3) *
+                self.q / ha.HUMAN_W_MIN).to(u.cm)
 
     @property
     def obstacle_n(self):

--- a/aguaclara/design/plant.py
+++ b/aguaclara/design/plant.py
@@ -30,20 +30,18 @@ class Plant:
         """
         # first guess planview area
         a_new = 1 * u.m**2
-        a_ratio = 0
+        a_ratio = 2  # set to >1+tolerance to start while loop
         tolerance = 0.01
-
+        a_floc_pv = (
+            self.floc.vol /
+            (self.floc.END_WATER_H + (self.floc.HL / 2))
+        )
         while a_ratio > (1 + tolerance):
             a_et_pv = a_new
-            a_floc_pv = (
-                self.floc.vol /
-                (self.floc.END_WATER_HEIGHT + (self.floc.HL / 2))
-            )
             a_etf_pv = a_et_pv + a_floc_pv
-
-            w_tot = a_etf_pv / self.floc.l_sed_max
+            w_tot = a_etf_pv / self.floc.sed_tank_l_max
             w_chan = w_tot / self.floc.channel_n
 
-            a_new = self.floc.L_MAX * w_chan
+            a_new = self.floc.l_max_vol * w_chan
             a_ratio = a_new / a_et_pv
         return a_new

--- a/tests/design/test_plant.py
+++ b/tests/design/test_plant.py
@@ -12,4 +12,4 @@ class PlantTest(unittest.TestCase):
         self.plant = Plant()
 
     def test_vel_grad_avg(self):
-        self.assertAlmostEqual(self.plant.ent_tank_a, 1 * (u.m ** 2), 0.001)
+        self.assertAlmostEqual(self.plant.ent_tank_a, 1.1457647546752496 * (u.m ** 2), 3)


### PR DESCRIPTION
Also fixed Plant naming to keep up with new floc stuff

Fletcher's comment:
"design/plant
- a_ratio is initialized as 0 but then you check if it’s greater than 1, so obviously it’s not going never enters the while loop
   - Pretty sure this was originally an error in my logic (sorry about that) but please fix it for me"