### PR TITLE
Fixed matplotlib backend in play.py

### DIFF
--- a/aguaclara/play.py
+++ b/aguaclara/play.py
@@ -23,8 +23,8 @@ import math
 import numpy as np
 import pandas as pd
 import matplotlib
-matplotlib.use('agg')
 import matplotlib.pyplot as plt
+plt.switch_backend('TKAgg')
 
 # Design imports
 # from aguaclara.design.lfom import LFOM    #NOTE: temporarily disabled for release 0.0.15 to prevent problems

--- a/aguaclara/play.py
+++ b/aguaclara/play.py
@@ -24,7 +24,6 @@ import numpy as np
 import pandas as pd
 import matplotlib
 import matplotlib.pyplot as plt
-plt.switch_backend('TKAgg')
 
 # Design imports
 # from aguaclara.design.lfom import LFOM    #NOTE: temporarily disabled for release 0.0.15 to prevent problems

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='aguaclara',
-      version='0.0.17',
+      version='0.0.18',
       description='Open source functions for AguaClara water treatment research and plant design.',
       url='https://github.com/AguaClara/aguaclara',
       author='AguaClara at Cornell',


### PR DESCRIPTION
Before, importing matplotlib.pyplot through play.py and then calling pyplot.plot() resulted in this error:
```
/anaconda3/lib/python3.6/site-packages/matplotlib/figure.py:445: UserWarning: Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.
  % get_backend())
```
I removed the backend setting altogether.