### PR TITLE
[BUG] pc.density_water returns a scalar

### DIFF
--- a/aguaclara/core/physchem.py
+++ b/aguaclara/core/physchem.py
@@ -69,7 +69,7 @@ def density_water(temp):
     ut.check_range([temp, ">0", "Temperature in Kelvin"])
     rhointerpolated = interpolate.CubicSpline(WATER_DENSITY_TABLE[0],
                                                     WATER_DENSITY_TABLE[1])
-    return rhointerpolated(temp)
+    return np.asscalar(rhointerpolated(temp))
 
 
 @u.wraps(u.m**2/u.s, [u.degK], False)


### PR DESCRIPTION
Fixed #152 , where `pc.density_water` gave errors because it was returning a 1 x 1 NumPy array, rather than a single value.