### PR TITLE
Isolate `onshapepy` dependency to `draw()`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ pint = "*"
 scipy = "*"
 onshapepy = "*"
 requests = ">=2.20.0"
+numpy = "==1.12.1"
 
 [dev-packages]
 codecov = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ pint = "*"
 scipy = "*"
 onshapepy = "*"
 requests = ">=2.20.0"
-numpy = "==1.12.1"
 
 [dev-packages]
 codecov = "*"

--- a/aguaclara/design/floc.py
+++ b/aguaclara/design/floc.py
@@ -12,7 +12,6 @@ import aguaclara.core.physchem as pc
 import aguaclara.core.pipes as pipes
 from aguaclara.core.units import unit_registry as u
 
-from onshapepy import Part
 import numpy as np
 
 # Ratio of the width of the gap between the baffle and the wall and the spacing
@@ -56,10 +55,6 @@ class Flocculator:
     HS_RATIO_MIN = 3.0
     RATIO_MAX_HS = 6.0
     SDR = 41.0
-
-    CAD = Part(
-        'https://cad.onshape.com/documents/b4cfd328713460beeb3125ac/w/3928b5c91bb0a0be7858d99e/e/6f2eeada21e494cebb49515f'
-    )
 
     def __init__(
             self,
@@ -298,7 +293,11 @@ class Flocculator:
 
     def draw(self):
         """Draw the Onshape flocculator model based off of this object."""
-        self.CAD.params = {
+        from onshapepy import Part
+        CAD = Part(
+            'https://cad.onshape.com/documents/b4cfd328713460beeb3125ac/w/3928b5c91bb0a0be7858d99e/e/6f2eeada21e494cebb49515f'
+        )
+        CAD.params = {
             'channel_L': self.channel_L,
             'channel_W': self.channel_W,
             'channel_H': self.downstream_H,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='aguaclara',
-      version='0.0.22',
+      version='0.0.23',
       description='Open source functions for AguaClara water treatment research and plant design.',
       url='https://github.com/AguaClara/aguaclara',
       author='AguaClara at Cornell',


### PR DESCRIPTION
This is a quick fix to [this issue](https://github.com/AguaClara/CEE4520/issues/51), in which CEE 4520 students had difficulty using design code due to not specifying `onshapepy` credentials.

`onshapepy` is isolated in that it will only ever be used when the `draw()` function is called, so students should still be able to do calculations on a flocculator without updating the Onshape drawing.

@monroews is it a necessity that students be able to change the Onshape drawing?