### PR TITLE
V0.1.0 Added air density function and fixed procoda_parser bug

### DIFF
--- a/aguaclara/core/physchem.py
+++ b/aguaclara/core/physchem.py
@@ -12,6 +12,21 @@ from scipy import interpolate, integrate
 
 gravity = con.GRAVITY
 
+######################Air################################
+@u.wraps(u.kg/u.m**3, [u.atm, u.g/u.mol, u.K], False)
+def density_air(Pressure, MolarMass, Temperature):
+
+"""Return the density of the air.
+:param Pressure: pressure of the air in the system
+:type Pressure: float
+:param MolarMass: molar mass of the air in the system
+:type MolarMass: float
+:param Temperature: Temperature of the air in the system
+:type Temperature: float
+:return: density of the air in the system
+:rtype: float"""
+    return ((Pressure*MolarMass)/(u.R*Temperature).to(u.kg/u.m**3)
+
 ###################### Simple geometry ######################
 """A few equations for useful geometry.
 Is there a geometry package that we should be using?"""

--- a/aguaclara/core/physchem.py
+++ b/aguaclara/core/physchem.py
@@ -13,23 +13,25 @@ from scipy import interpolate, integrate
 gravity = con.GRAVITY
 
 ######################Air################################
-@u.wraps(u.kg/u.m**3, [u.atm, u.g/u.mol, u.K], False)
 def density_air(Pressure, MolarMass, Temperature):
+    """Return the density of the air.
 
-"""Return the density of the air.
-:param Pressure: pressure of the air in the system
-:type Pressure: float
-:param MolarMass: molar mass of the air in the system
-:type MolarMass: float
-:param Temperature: Temperature of the air in the system
-:type Temperature: float
-:return: density of the air in the system
-:rtype: float"""
-    return ((Pressure*MolarMass)/(u.R*Temperature).to(u.kg/u.m**3)
+    :param Pressure: pressure of the air in the system
+    :type Pressure: float
+    :param MolarMass: molar mass of the air in the system
+    :type MolarMass: float
+    :param Temperature: Temperature of the air in the system
+    :type Temperature: float
+
+    :return: density of the air in the system
+    :rtype: float
+    """
+    return (Pressure * MolarMass / (u.R * Temperature)).to(u.kg/u.m**3)
 
 ###################### Simple geometry ######################
 """A few equations for useful geometry.
-Is there a geometry package that we should be using?"""
+Is there a geometry package that we should be using?
+"""
 
 @u.wraps(u.m**2, u.m, False)
 def area_circle(DiamCircle):

--- a/aguaclara/research/procoda_parser.py
+++ b/aguaclara/research/procoda_parser.py
@@ -114,15 +114,13 @@ def data_from_dates(path, dates):
     :return: a list DataFrame objects representing the ProCoDA datalogs corresponding with the given dates
     :rtype: pandas.DataFrame list
     """
-    if path[-1] != os.path.sep:
-        path += os.path.sep
 
     if not isinstance(dates, list):
         dates = [dates]
 
     data = []
     for d in dates:
-        filepath = path + 'datalog ' + d + '.xls'
+        filepath = os.path.join(path, 'datalog ' + d + '.xls')
         data.append(remove_notes(pd.read_csv(filepath, delimiter='\t')))
 
     return data

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='aguaclara',
-      version='0.0.25',
+      version='0.1.0',
       description='Open source functions for AguaClara water treatment research and plant design.',
       url='https://github.com/AguaClara/aguaclara',
       author='AguaClara at Cornell',

--- a/tests/core/test_physchem.py
+++ b/tests/core/test_physchem.py
@@ -12,8 +12,34 @@ By: Ethan Keller
 #before this file is released to the Master branch!
 
 from aguaclara.core.units import unit_registry as u
-from aguaclara.core import physchem as pc
 import unittest
+
+developing = False
+if developing:
+    import sys
+    sys.path.append("..//../aguaclara/research")
+    import physchem as pc
+else:
+    from aguaclara.core import physchem as pc
+
+class AirTest(unittest.TestCase):
+    """Test the air density function"""
+    def assertAlmostEqualQuantity(self, first, second, places=7):
+        self.assertAlmostEqual(first.magnitude, second.magnitude, places)
+        self.assertEqual(first.units, second.units, places)
+    def test_air_density(self):
+        answer = 0.00930233*u.atm*u.g/u.mol/u.K
+        self.assertAlmostEqualQuantity(density_air(1*u.atm, 2*u.g/u.mol, 215*u.K), answer)
+        answer = 0*u.atm*u.g/u.mol / u.K
+        self.assertAlmostEqualQuantity(density_air(0*u.atm, 2*u.g/u.mol, 215*u.K), answer)
+        answer = 0*u.kPa*u.g/u.mol / u.K
+        self.assertAlmostEqualQuantity(density_air(0*u.pascal, 2*u.g/u.mol, 215*u.K), answer)
+        answer = 0*u.mmHg*u.g/u.mol / u.K
+        self.assertAlmostEqualQuantity(density_air(0*u.mmHg, 2*u.g/u.mol, 215*u.K), answer)
+        answer = 0.00930233*u.kPa*u.g/u.mol/u.K
+        self.assertAlmostEqualQuantity(density_air(1*u.pascal, 2*u.g/u.mol, 215*u.K), answer)
+        answer = 0.00930233*u.mmHg*u.g/u.mol/u.K
+        self.assertAlmostEqualQuantity(density_air(1*u.mmHg, 2*u.g/u.mol, 215*u.K), answer)
 
 class GeometryTest(unittest.TestCase):
     """Test the circular area and diameter functions."""

--- a/tests/core/test_physchem.py
+++ b/tests/core/test_physchem.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 """
-Created on Fri Jul  7 11:51:51 2017
+Created on Fri Jul 7 11:51:51 2017
 
 @author: Sage Weber-Shirk
 
-Last modified: Mon Aug 17 2017
-By: Ethan Keller
+Last modified: Tue Jun 4 2019
+By: Hannah Si
 """
 
 #Note: All answer values in this file should be checked against MathCad
@@ -17,7 +17,7 @@ import unittest
 developing = False
 if developing:
     import sys
-    sys.path.append("..//../aguaclara/research")
+    sys.path.append("../../aguaclara/core")
     import physchem as pc
 else:
     from aguaclara.core import physchem as pc
@@ -27,19 +27,18 @@ class AirTest(unittest.TestCase):
     def assertAlmostEqualQuantity(self, first, second, places=7):
         self.assertAlmostEqual(first.magnitude, second.magnitude, places)
         self.assertEqual(first.units, second.units, places)
+
     def test_air_density(self):
-        answer = 0.00930233*u.atm*u.g/u.mol/u.K
-        self.assertAlmostEqualQuantity(density_air(1*u.atm, 2*u.g/u.mol, 215*u.K), answer)
-        answer = 0*u.atm*u.g/u.mol / u.K
-        self.assertAlmostEqualQuantity(density_air(0*u.atm, 2*u.g/u.mol, 215*u.K), answer)
-        answer = 0*u.kPa*u.g/u.mol / u.K
-        self.assertAlmostEqualQuantity(density_air(0*u.pascal, 2*u.g/u.mol, 215*u.K), answer)
-        answer = 0*u.mmHg*u.g/u.mol / u.K
-        self.assertAlmostEqualQuantity(density_air(0*u.mmHg, 2*u.g/u.mol, 215*u.K), answer)
-        answer = 0.00930233*u.kPa*u.g/u.mol/u.K
-        self.assertAlmostEqualQuantity(density_air(1*u.pascal, 2*u.g/u.mol, 215*u.K), answer)
-        answer = 0.00930233*u.mmHg*u.g/u.mol/u.K
-        self.assertAlmostEqualQuantity(density_air(1*u.mmHg, 2*u.g/u.mol, 215*u.K), answer)
+        answer = 1.29320776*u.kg/u.m**3
+        self.assertAlmostEqualQuantity(pc.density_air(1*u.atm, 28.97*u.g/u.mol, 273*u.K), answer)
+        answer = 2.06552493*u.kg/u.m**3
+        self.assertAlmostEqualQuantity(pc.density_air(5*u.atm, 10*u.g/u.mol, 295*u.K), answer)
+        answer = 1.62487961*u.kg/u.m**3
+        self.assertAlmostEqualQuantity(pc.density_air(101325*u.Pa, 40*u.g/u.mol, 300*u.K), answer)
+        answer = 0.20786109*u.kg/u.m**3
+        self.assertAlmostEqualQuantity(pc.density_air(700*u.mmHg, 5*u.g/u.mol, 270*u.K), answer)
+        answer = 0*u.kg/u.m**3
+        self.assertAlmostEqualQuantity(pc.density_air(0*u.atm, 28.97*u.g/u.mol, 273*u.K), answer)
 
 class GeometryTest(unittest.TestCase):
     """Test the circular area and diameter functions."""


### PR DESCRIPTION
This release patches a file path bug in `procoda_parser`, in which a path was incorrectly joined for Windows operating systems (#203). 

It also adds a function in `aguaclara.core.physchem` for calculating air density, which we forgot to include when we removed the incorrect air density constant in a previous release (#191).