### PR TITLE
Add baffle scaffold input

### DIFF
--- a/aguaclara/design/floc.py
+++ b/aguaclara/design/floc.py
@@ -73,7 +73,8 @@ class Flocculator(Component):
                  gt=37000,
                  hl = 40.0 * u.cm,
                  end_water_depth = 2.0 * u.m,
-                 drain_t=30.0 * u.min):
+                 drain_t=30.0 * u.min,
+                 baffle_scaffold_id=1.45 * u.cm):
         super().__init__(q = q, temp = temp)
         self.l_max = l_max
         self.gt = gt


### PR DESCRIPTION
We just needed to specify the inner diameter of the flocculator baffle scaffolding for ease of use in Onshape on AIDE Template's side.