### PR TITLE
New import structure

### DIFF
--- a/aguaclara/__init__.py
+++ b/aguaclara/__init__.py
@@ -1,0 +1,27 @@
+from aguaclara.core.constants import *
+from aguaclara.core.drills import *
+from aguaclara.core.head_loss import *
+from aguaclara.core.materials import *
+from aguaclara.core.physchem import *
+from aguaclara.core.pipeline import *
+from aguaclara.core.pipes import *
+from aguaclara.core.utility import *
+
+from aguaclara.design.cdc import CDC
+from aguaclara.design.component import Component
+from aguaclara.design.ent_floc import EntTankFloc
+from aguaclara.design.ent import EntranceTank
+from aguaclara.design.filter import Filter
+from aguaclara.design.floc import Flocculator
+import aguaclara.design.human_access as ha
+from aguaclara.design.lfom import LFOM
+from aguaclara.design.plant import Plant
+from aguaclara.design.sed_chan import SedimentationChannel
+from aguaclara.design.sed_tank import SedimentationTank
+from aguaclara.design.sed import Sedimentor
+
+from aguaclara.research.environmental_processes_analysis import *
+from aguaclara.research.floc_model import *
+from aguaclara.research.procoda_parser import *
+from aguaclara.research.peristaltic_pump import *
+from aguaclara.research.stock_qc import *

--- a/aguaclara/core/constants.py
+++ b/aguaclara/core/constants.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Constant quantities of widely-accepted physical properties."""
 
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 # NOTE: "#: <optional_description>"  required for Sphinx autodocumentation
 

--- a/aguaclara/core/drills.py
+++ b/aguaclara/core/drills.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Lists of drill bit diameters."""
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 import numpy as np
 

--- a/aguaclara/core/head_loss.py
+++ b/aguaclara/core/head_loss.py
@@ -8,7 +8,7 @@ import aguaclara.core.physchem as pc
 import aguaclara.core.constants as con
 import aguaclara.core.materials as mats
 import aguaclara.core.utility as ut
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 import numpy as np
 

--- a/aguaclara/core/materials.py
+++ b/aguaclara/core/materials.py
@@ -3,7 +3,7 @@
 Data for materials that are used in the construction of AguaClara water
 treatment plants.
 """
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 #:
 PVC_PIPE_ROUGH = 0.12 * u.mm

--- a/aguaclara/core/physchem.py
+++ b/aguaclara/core/physchem.py
@@ -2,7 +2,7 @@
 and chemical unit processes for AguaClara water treatment plants.
 """
 
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import aguaclara.core.materials as mat
 import aguaclara.core.constants as con
 import aguaclara.core.utility as ut

--- a/aguaclara/core/pipeline.py
+++ b/aguaclara/core/pipeline.py
@@ -3,7 +3,7 @@ pipeline design.
 
 """
 
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 from aguaclara.core import physchem as pc
 import aguaclara.core.constants as con
 import aguaclara.core.materials as mats

--- a/aguaclara/core/pipes.py
+++ b/aguaclara/core/pipes.py
@@ -4,7 +4,7 @@ outer diameters of pipes based on their standard dimension ratio (SDR).
 
 #Let's begin to create the pipe database
 # https://docs.python.org/2/library/csv.html
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import numpy as np
 import pandas as pd
 # load the pipedb from a csv file

--- a/aguaclara/core/units.py
+++ b/aguaclara/core/units.py
@@ -3,9 +3,9 @@
 The ``pint`` package supports arithmetic involving **physical quantities**
 each of which has a magnitude and units, for example 1 cm or 3 kg m/s^2.
 The units of a quantity come from ``pint``'s **unit registry**. This module
-contains a single global unit registry ``unit_registry`` that can be used by any
+contains a single global unit registry ``u`` that can be used by any
 number of other modules. The ``aguaclara`` has also defined and added some of
-its own units to the ``unit_registry``:
+its own units to the ``u``:
 
   * NTU = 1.47 * (mg / L)
   * dollar = [money] = USD
@@ -15,7 +15,7 @@ its own units to the ``unit_registry``:
 
 :Examples:
 
->>> from aguaclara.core.units import unit_registry as u
+>>> from aguaclara.core.units import u as u
 >>> rpm = 10 * u.rev/u.min
 >>> rpm
 <Quantity(10.0, 'rev / minute')>
@@ -31,7 +31,7 @@ import os
 import pint
 import pandas as pd
 
-unit_registry = pint.UnitRegistry(
+u = pint.UnitRegistry(
     system='mks',
     autoconvert_offset_to_baseunit=True
 )
@@ -40,10 +40,10 @@ unit_registry = pint.UnitRegistry(
 # default formatting includes 4 significant digits.
 # This can be overridden on a per-print basis with
 # print('{:.3f}'.format(3 * ureg.m / 9)).
-unit_registry.default_format = '.4g'
+u.default_format = '.4g'
 pd.options.display.float_format = '{:,.4g}'.format
 
-unit_registry.load_definitions(os.path.join(os.path.dirname(__file__),
+u.load_definitions(os.path.join(os.path.dirname(__file__),
                                             "data", "unit_definitions.txt"))
 
 
@@ -56,7 +56,7 @@ def set_sig_figs(n):
 
     :Examples:
 
-    >>> from aguaclara.core.units import set_sig_figs, unit_registry as u
+    >>> from aguaclara.core.units import set_sig_figs, u as u
     >>> h = 2.5532532522352543*u.m
     >>> e = 25532532522352543*u.m
     >>> print('h before sigfig adjustment:',h)
@@ -69,5 +69,5 @@ def set_sig_figs(n):
     >>> print('e after sigfig adjustment:',e)
     e after sigfig adjustment: 2.553253252e+16 meter
     """
-    unit_registry.default_format = '.' + str(n) + 'g'
+    u.default_format = '.' + str(n) + 'g'
     pd.options.display.float_format = ('{:,.' + str(n) + '}').format

--- a/aguaclara/core/units.py
+++ b/aguaclara/core/units.py
@@ -31,11 +31,12 @@ import os
 import pint
 import pandas as pd
 
-u = pint.UnitRegistry(
+# A global unit registry that can be used by any of other module.
+unit_registry = pint.UnitRegistry(
     system='mks',
     autoconvert_offset_to_baseunit=True
 )
-"""A global unit registry that can be used by any of other module."""
+u = unit_registry
 
 # default formatting includes 4 significant digits.
 # This can be overridden on a per-print basis with

--- a/aguaclara/core/units.py
+++ b/aguaclara/core/units.py
@@ -15,7 +15,7 @@ its own units to the ``u``:
 
 :Examples:
 
->>> from aguaclara.core.units import u as u
+>>> from aguaclara.core.units import u
 >>> rpm = 10 * u.rev/u.min
 >>> rpm
 <Quantity(10.0, 'rev / minute')>

--- a/aguaclara/core/utility.py
+++ b/aguaclara/core/utility.py
@@ -8,7 +8,7 @@ Example:
     >>> ut.round_sig_figs(1234567, 3)
     1230000
 """
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 import numpy as np
 from math import log10, floor, ceil

--- a/aguaclara/design/cdc.py
+++ b/aguaclara/design/cdc.py
@@ -10,7 +10,7 @@ Example:
 """
 import aguaclara.core.physchem as pc
 import aguaclara.core.utility as ut
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import aguaclara.core.constants as con
 from aguaclara.design.component import Component
 

--- a/aguaclara/design/component.py
+++ b/aguaclara/design/component.py
@@ -24,7 +24,7 @@ Example:
             super().__init__(**kwargs)
             super().propogate_config()
 """
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import aguaclara.core.utility as ut
 
 import numpy as np

--- a/aguaclara/design/ent.py
+++ b/aguaclara/design/ent.py
@@ -15,7 +15,7 @@ import aguaclara.core.head_loss as hl
 import aguaclara.core.materials as mat
 import aguaclara.core.physchem as pc
 import aguaclara.core.pipes as pipe
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import aguaclara.core.utility as ut
 
 from aguaclara.design.component import Component

--- a/aguaclara/design/filter.py
+++ b/aguaclara/design/filter.py
@@ -1,5 +1,5 @@
-from aguaclara.core.units import unit_registry as u
-
+from aguaclara.core.units import u
+from aguaclara.design.component import Component
 
 class Filter(Component):
 

--- a/aguaclara/design/floc.py
+++ b/aguaclara/design/floc.py
@@ -11,7 +11,7 @@ import aguaclara.core.head_loss as hl
 import aguaclara.design.human_access as ha
 import aguaclara.core.physchem as pc
 import aguaclara.core.pipes as pipes
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 from aguaclara.design.component import Component
 
 import numpy as np

--- a/aguaclara/design/human_access.py
+++ b/aguaclara/design/human_access.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Constant dimensions to allow for human access within a plant."""
 
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 WALKWAY_W_DEFAULT = 1 * u.m
 DRAIN_CHAN_WALKWAY_W = 1.2 * u.m

--- a/aguaclara/design/lfom.py
+++ b/aguaclara/design/lfom.py
@@ -13,7 +13,7 @@ import aguaclara.core.physchem as pc
 import aguaclara.core.pipes as pipe
 import aguaclara.core.utility as ut
 import aguaclara.core.drills as drills
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 from aguaclara.design.component import Component
 
 import numpy as np

--- a/aguaclara/design/plant.py
+++ b/aguaclara/design/plant.py
@@ -9,7 +9,7 @@ from aguaclara.design.sed import Sedimentor
 from aguaclara.design.sed_tank import SedimentationTank
 from aguaclara.design.sed_chan import SedimentationChannel
 
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 
 class Plant(Component):

--- a/aguaclara/design/sed.py
+++ b/aguaclara/design/sed.py
@@ -11,7 +11,7 @@ Example:
 from aguaclara.design.sed_tank import SedimentationTank
 from aguaclara.design.sed_chan import SedimentationChannel
 from aguaclara.design.component import Component
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import aguaclara.core.constants as con
 
 import numpy as np

--- a/aguaclara/design/sed_chan.py
+++ b/aguaclara/design/sed_chan.py
@@ -8,7 +8,7 @@ Example:
     >>> sed_chan.inlet_w
     <Quantity(59.52755905511811, 'inch')>
 """
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import aguaclara.core.constants as con
 import aguaclara.core.materials as mat
 import aguaclara.core.utility as ut

--- a/aguaclara/design/sed_tank.py
+++ b/aguaclara/design/sed_tank.py
@@ -6,7 +6,7 @@ Example:
     >>> sed_tank.diffuser_hl
     <Quantity(0.009259259259259259, 'centimeter')>
 """
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import aguaclara.core.constants as con
 import aguaclara.core.materials as mat
 import aguaclara.core.pipes as pipe

--- a/aguaclara/play.py
+++ b/aguaclara/play.py
@@ -9,14 +9,12 @@ import only necessary modules.
 Example:
     >>> from aguaclara.play import *
 """
-
 import math
 import numpy as np
 import pandas as pd
 import matplotlib
 import matplotlib.style
 import matplotlib.pyplot as plt
-import warnings
 
 import aguaclara.core.constants as con
 from aguaclara.core import drills
@@ -25,20 +23,29 @@ import aguaclara.core.materials as mat
 from aguaclara.core import physchem as pc
 from aguaclara.core import pipeline
 import aguaclara.core.pipes as pipe
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import aguaclara.core.utility as ut
 
-# Temporarily disabled for release 0.0.15 to prevent problems with lacking
-# Onshapepy setup. Re-enable when Onshapepy backend has been resolved.
-# from aguaclara.design.lfom import LFOM
-# from aguaclara.design.floc import Flocculator
+from aguaclara.design.cdc import CDC
+from aguaclara.design.component import Component
+from aguaclara.design.ent_floc import EntTankFloc
+from aguaclara.design.ent import EntranceTank
+from aguaclara.design.filter import Filter
+from aguaclara.design.floc import Flocculator
 import aguaclara.design.human_access as ha
+from aguaclara.design.lfom import LFOM
+from aguaclara.design.plant import Plant
+from aguaclara.design.sed_chan import SedimentationChannel
+from aguaclara.design.sed_tank import SedimentationTank
+from aguaclara.design.sed import Sedimentor
 
 import aguaclara.research.environmental_processes_analysis as epa
 import aguaclara.research.floc_model as fm
 import aguaclara.research.procoda_parser as procoda_parser
 import aguaclara.research.peristaltic_pump as peristaltic_pump
 import aguaclara.research.stock_qc as stock_qc
+
+import aguaclara as ac
 
 def set_sig_figs(n=4):
     """Set the number of significant figures used to print Pint, Pandas, and

--- a/aguaclara/research/environmental_processes_analysis.py
+++ b/aguaclara/research/environmental_processes_analysis.py
@@ -1,5 +1,5 @@
 from aguaclara.research.procoda_parser import *
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import pandas as pd
 import numpy as np
 from scipy import special
@@ -111,7 +111,7 @@ def ANC_closed(pH, total_carbonates):
     :Examples:
 
     >>> from aguaclara.research.environmental_processes_analysis import ANC_closed
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> round(ANC_closed(10, 1*u.mol/u.L), 7)
     <Quantity(1.359831, 'equivalent / liter')>
     """
@@ -193,7 +193,7 @@ def O2_sat(P_air, temp):
     :Examples:
 
     >>> from aguaclara.research.environmental_processes_analysis import O2_sat
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> round(O2_sat(1*u.atm , 300*u.kelvin), 7)
     <Quantity(8.0931572, 'milligram / liter')>
     """
@@ -254,7 +254,7 @@ def CMFR(t, C_initial, C_influent):
     :Examples:
 
     >>> from aguaclara.research.environmental_processes_analysis import CMFR
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> round(CMFR(0.1, 0*u.mg/u.L, 10*u.mg/u.L), 7)
     <Quantity(0.9516258, 'milligram / liter')>
     >>> round(CMFR(0.9, 5*u.mg/u.L, 10*u.mg/u.L), 7)
@@ -331,7 +331,7 @@ def Tracer_CMFR_N(t_seconds, t_bar, C_bar, N):
     :Examples:
 
     >>> from aguaclara.research.environmental_processes_analysis import Tracer_CMFR_N
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> Tracer_CMFR_N([1, 2, 3, 4, 5]*u.s, 5*u.s, 10*u.mg/u.L, 3)
     <Quantity([2.96358283 6.50579498 8.03352597 7.83803116 6.72125423], 'milligram / liter')>
     """
@@ -391,7 +391,7 @@ def Tracer_AD_Pe(t_seconds, t_bar, C_bar, Pe):
     :Examples:
 
     >>> from aguaclara.research.environmental_processes_analysis import Tracer_AD_Pe
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> Tracer_AD_Pe([1, 2, 3, 4, 5]*u.s, 5*u.s, 10*u.mg/u.L, 5)
     <Quantity([0.25833732 3.23793989 5.8349833  6.62508831 6.30783131], 'milligram / liter')>
 

--- a/aguaclara/research/floc_model.py
+++ b/aguaclara/research/floc_model.py
@@ -6,7 +6,7 @@ flocs based on the chemical interactions of clay, coagulant, and humic acid.
 
 ######################### Imports #########################
 import numpy as np
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 from aguaclara.core import physchem as pc, utility as ut
 
 u.enable_contexts('chem')

--- a/aguaclara/research/peristaltic_pump.py
+++ b/aguaclara/research/peristaltic_pump.py
@@ -1,4 +1,4 @@
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import numpy as np
 import pandas as pd
 import os
@@ -35,7 +35,7 @@ def vol_per_rev_3_stop(color="", inner_diameter=0):
     :Examples:
 
     >>> from aguaclara.research.peristaltic_pump import vol_per_rev_3_stop
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> round(vol_per_rev_3_stop(color="yellow-blue"), 6)
     <Quantity(0.148846, 'milliliter / rev')>
     >>> round(vol_per_rev_3_stop(inner_diameter=.20*u.mm), 6)
@@ -60,7 +60,7 @@ def ID_colored_tube(color):
     :Examples:
 
     >>> from aguaclara.research.peristaltic_pump import ID_colored_tube
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> ID_colored_tube("yellow-blue")
     <Quantity(1.52, 'millimeter')>
     >>> ID_colored_tube("orange-yellow")
@@ -88,7 +88,7 @@ def vol_per_rev_LS(id_number):
     :Examples:
 
     >>> from aguaclara.research.peristaltic_pump import vol_per_rev_LS
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> vol_per_rev_LS(13)
     <Quantity(0.06, 'milliliter / turn')>
     >>> vol_per_rev_LS(18)
@@ -116,7 +116,7 @@ def flow_rate(vol_per_rev, rpm):
     :Examples:
 
     >>> from aguaclara.research.peristaltic_pump import flow_rate
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> flow_rate(3*u.mL/u.rev, 5*u.rev/u.min)
     <Quantity(0.25, 'milliliter / second')>
     """

--- a/aguaclara/research/procoda_parser.py
+++ b/aguaclara/research/procoda_parser.py
@@ -1,4 +1,4 @@
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta

--- a/aguaclara/research/stock_qc.py
+++ b/aguaclara/research/stock_qc.py
@@ -1,4 +1,4 @@
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 
 class Stock(object):
@@ -30,7 +30,7 @@ class Variable_C_Stock(Stock):
     :Examples:
 
     >>> from aguaclara.research.stock_qc import Variable_C_Stock
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> reactor = Variable_C_Stock(Q_sys = 1*u.mL/u.s, C_sys = 1.4*u.mg/u.L, Q_stock = .01*u.mL/u.s)
     >>> reactor.C_stock()
     <Quantity(140.0, 'milligram / liter')>
@@ -154,7 +154,7 @@ class Variable_Q_Stock(Stock):
     :Examples:
 
     >>> from aguaclara.research.stock_qc import Variable_Q_Stock
-    >>> from aguaclara.core.units import unit_registry as u
+    >>> from aguaclara.core.units import u
     >>> reactor = Variable_Q_Stock(Q_sys = 1*u.mL/u.s, C_sys = 1.4*u.mg/u.L, C_stock = 7.6*u.mg/u.L)
     >>> reactor.Q_stock()
     <Quantity(0.18421052631578946, 'milliliter / second')>

--- a/tests/core/test_head_loss.py
+++ b/tests/core/test_head_loss.py
@@ -1,6 +1,6 @@
 import unittest
 import aguaclara.core.head_loss as k
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 from aguaclara.core import pipes as pipe
 
 """ There are still many cases to test."""

--- a/tests/core/test_physchem.py
+++ b/tests/core/test_physchem.py
@@ -11,7 +11,7 @@ By: Hannah Si
 #Note: All answer values in this file should be checked against MathCad
 #before this file is released to the Master branch!
 
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import unittest
 
 developing = False

--- a/tests/core/test_pipedatabase.py
+++ b/tests/core/test_pipedatabase.py
@@ -1,5 +1,5 @@
 import unittest
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 from aguaclara.core import pipes as pipe
 
 

--- a/tests/core/test_pipeline.py
+++ b/tests/core/test_pipeline.py
@@ -1,5 +1,5 @@
 import unittest
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import numpy as np
 import aguaclara.core.pipeline as pipeline
 

--- a/tests/core/test_pipes.py
+++ b/tests/core/test_pipes.py
@@ -4,7 +4,7 @@ import os
 import pandas as pd
 import numpy as np
 
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 from aguaclara.core import pipes
 
 # TODO: Rewrite this testing class.

--- a/tests/design/test_ent.py
+++ b/tests/design/test_ent.py
@@ -1,5 +1,5 @@
 from aguaclara.design.ent import EntranceTank
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 import pytest
 

--- a/tests/design/test_ent_floc.py
+++ b/tests/design/test_ent_floc.py
@@ -1,5 +1,5 @@
 from aguaclara.design.ent_floc import EntTankFloc
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 import aguaclara.core.utility as ut
 
 import pytest

--- a/tests/design/test_floc.py
+++ b/tests/design/test_floc.py
@@ -1,5 +1,5 @@
 from aguaclara.design.floc import Flocculator
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 import pytest
 

--- a/tests/design/test_lfom.py
+++ b/tests/design/test_lfom.py
@@ -1,5 +1,5 @@
 from aguaclara.design.lfom import LFOM
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 import pytest
 import numpy as np

--- a/tests/design/test_sed.py
+++ b/tests/design/test_sed.py
@@ -1,5 +1,5 @@
 from aguaclara.design.sed import Sedimentor
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 import pytest
 

--- a/tests/design/test_sed_chan.py
+++ b/tests/design/test_sed_chan.py
@@ -1,5 +1,5 @@
 from aguaclara.design.sed_chan import SedimentationChannel
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 import pytest
 

--- a/tests/design/test_sed_tank.py
+++ b/tests/design/test_sed_tank.py
@@ -1,5 +1,5 @@
 from aguaclara.design.sed_tank import SedimentationTank
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 import pytest
 

--- a/tests/research/test_floc_model.py
+++ b/tests/research/test_floc_model.py
@@ -3,7 +3,7 @@ Tests for the research package's floc_model functions
 """
 
 import unittest
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 developing = False
 if developing:

--- a/tests/research/test_peristaltic_pump.py
+++ b/tests/research/test_peristaltic_pump.py
@@ -3,7 +3,7 @@ Tests for the research package's tube_sizing module.
 """
 
 import unittest
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 developing = False
 if developing:

--- a/tests/research/test_stock_qc.py
+++ b/tests/research/test_stock_qc.py
@@ -2,7 +2,7 @@
 Tests for the research package's tube_sizing module.
 """
 import unittest
-from aguaclara.core.units import unit_registry as u
+from aguaclara.core.units import u
 
 developing = False
 if developing:


### PR DESCRIPTION
This is an implementation of #214, where we add new options for users to import `aguaclara` code.

The old option with `aguaclara.play` still exists and retains the exact same functionality:

```python
from aguaclara.play import *

temp = 20 * u.degC
print(pc.viscosity_kinematic(temp))
```

The new option matches the recommended import style of NumPy and puts all functionality under the `ac` name. It also is more barebones in that:
- Other non-`aguaclara` packages (`numpy`, `matplotlib`, etc) are not imported to maintain separation
- The Pint unit registry must be imported separately from the `aguaclara.core.units` module, now with a new, simpler format

```python
import aguaclara as ac
from aguaclara.core.units import u

temp = 20 * u.degC
print(ac.viscosity_kinematic(temp))
```

`from aguaclara.play import *` also imports `aguaclara` as `ac` and the `u`nit registry as yet another option.