### PR TITLE
Deprecate round_sf for round_sig_figs

### DIFF
--- a/aguaclara/core/utility.py
+++ b/aguaclara/core/utility.py
@@ -73,9 +73,19 @@ def round_sig_figs(num, figs=4):
     return num
 
 def round_sf(num, figs=4):
+    """Round a number to some amount of significant figures.
+
+    Args:
+        - ``num (float)``: Value to be rounded (optional units)
+        - ``figs (int)``: Number of significant digits to be rounded to 
+          (recommended, defaults to 4)
+
+    Note: This function will be deprecated after 21 Dec 2019. Use
+    round_sig_figs instead.
+    """
     warnings.warn(
         'round_sf will be deprecated after 21 Dec 2019. Use '
-            'ceil_step instead.',
+            'round_sig_figs instead.',
         FutureWarning
     )
     round_sig_figs(num, figs = figs)

--- a/aguaclara/core/utility.py
+++ b/aguaclara/core/utility.py
@@ -72,6 +72,14 @@ def round_sig_figs(num, figs=4):
 
     return num
 
+def round_sf(num, figs=4):
+    warnings.warn(
+        'round_sf will be deprecated after 21 Dec 2019. Use '
+            'ceil_step instead.',
+        FutureWarning
+    )
+    round_sig_figs(num, figs = figs)
+
 @optional_units([0, 1], ['num', 'step'])
 def _stepper(num, step=10, func=round):
     """Round a number to be a multiple of some step.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='aguaclara',
-      version='0.1.2',
+      version='0.1.3',
       description='Open source functions for AguaClara water treatment research and plant design.',
       url='https://github.com/AguaClara/aguaclara',
       author='AguaClara at Cornell',


### PR DESCRIPTION
My bad - I created a new `utility.round_sig_figs` function and forgot to leave `utility.round_sf` in with a deprecation warning!