### PR TITLE
ProCoDA Parser Enhancements

### DIFF
--- a/aguaclara/research/procoda_parser.py
+++ b/aguaclara/research/procoda_parser.py
@@ -337,7 +337,7 @@ def get_data_by_state(path, dates, state, column, extension=".tsv"):
     return data_agg
 
 
-def plot_columns(path, columns, x_axis=None, sep='\t'):
+def plot_columns(path, columns, x_axis=None):
     """Plot columns of data, located by labels, in the given data file.
 
     :param path: The file path of the ProCoDA data file
@@ -352,7 +352,7 @@ def plot_columns(path, columns, x_axis=None, sep='\t'):
     :return: A list of Line2D objects representing the plotted data
     :rtype: matplotlib.lines.Line2D list
     """
-    df = pd.read_csv(path, sep=sep)
+    df = pd.read_csv(path, delimiter='\t')
     df = remove_notes(df)
 
     if isinstance(columns, str):
@@ -375,7 +375,7 @@ def plot_columns(path, columns, x_axis=None, sep='\t'):
         raise ValueError('columns must be a string or list of strings')
 
 
-def iplot_columns(path, columns, x_axis=None, sep='\t'):
+def iplot_columns(path, columns, x_axis=None):
     """Plot columns of data, located by indexes, in the given data file.
 
     :param path: The file path of the ProCoDA data file
@@ -390,7 +390,7 @@ def iplot_columns(path, columns, x_axis=None, sep='\t'):
     :return: a list of Line2D objects representing the plotted data
     :rtype: matplotlib.lines.Line2D list
     """
-    df = pd.read_csv(path, sep=sep)
+    df = pd.read_csv(path, delimiter='\t')
     df = remove_notes(df)
 
     if isinstance(columns, int):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'aguaclara',
-    version = '0.1.6',
+    version = '0.1.7',
     description = (
         'An open-source Python package for designing and performing research '
         'on AguaClara water treatment plants.'

--- a/tests/research/test_ProCoDA_Parser.py
+++ b/tests/research/test_ProCoDA_Parser.py
@@ -23,24 +23,24 @@ class TestProCoDAParser(unittest.TestCase):
         data_day2[0][0] = 0  # to remove scientific notation "e-"
 
         # SINGLE COLUMN, ONE DAY
-        output = get_data_by_time(path=path, columns=0, dates="6-14-2018", start_time="12:20", end_time="13:00")
+        output = get_data_by_time(path=path, columns=0, dates="6-14-2018", start_time="12:20", end_time="13:00", extension=".xls")
         self.assertSequenceEqual(np.round(output, 5).tolist(), data_day1[0][1041:1282])
 
         # SINGLE COLUMN, TWO DAYS
         output = get_data_by_time(path=path, columns=0, dates=["6-14-2018", "6-15-2018"],
-                                  start_time="12:20", end_time="10:50")
+                                  start_time="12:20", end_time="10:50", extension=".xls")
         time_column = data_day1[0][1041:] + np.round(np.array(data_day2[0][:3901])+1, 5).tolist()
         self.assertSequenceEqual(np.round(output, 5).tolist(), time_column)
 
         # MULTI COLUMN, ONE DAY
         output = get_data_by_time(path=path, columns=[0, 4], dates=["6-14-2018"], start_time="12:20",
-                                  end_time="13:00")
+                                  end_time="13:00", extension=".xls")
         self.assertSequenceEqual(np.round(output[0], 5).tolist(), data_day1[0][1041:1282])
         self.assertSequenceEqual(np.round(output[1], 5).tolist(), data_day1[1][1041:1282])
 
         # MULTI COLUMN, TWO DAYS
         output = get_data_by_time(path=path, columns=[0, 4], dates=["6-14-2018", "6-15-2018"],
-                                  start_time="12:20", end_time="10:50")
+                                  start_time="12:20", end_time="10:50", extension=".xls")
         time_column = data_day1[0][1041:] + np.round(np.array(data_day2[0][:3901])+1, 5).tolist()
         self.assertSequenceEqual(np.round(output[0], 5).tolist(), time_column)
         self.assertSequenceEqual(np.round(output[1], 5).tolist(), data_day1[1][1041:]+data_day2[1][:3901])
@@ -96,7 +96,7 @@ class TestProCoDAParser(unittest.TestCase):
         '''
         path = os.path.join(os.path.dirname(__file__), '.', 'data')
 
-        output = get_data_by_state(path, dates=["6-19-2013"], state=1, column=1)  # , "6-20-2013"
+        output = get_data_by_state(path, dates=["6-19-2013"], state=1, column=1, extension=".xls")  # , "6-20-2013"
 
         datafile = pd.read_csv(path + "/datalog 6-19-2013.xls", delimiter='\t')
         time_and_data1 = np.array([pd.to_numeric(datafile.iloc[:, 0]),
@@ -222,7 +222,8 @@ class TestProCoDAParser(unittest.TestCase):
 
     def test_read_state(self):
         path = os.path.join(os.path.dirname(__file__), '.', 'data', '')
-        time, data = read_state(["6-19-2013", "6-20-2013"], 1, 28, "mL/s", path)
+        time, data = read_state(["6-19-2013", "6-20-2013"], 1, 28, "mL/s", path,
+                                extension=".xls")
         time = np.round(time, 5)
         self.assertSequenceEqual(
         time.tolist()[1000:1100],
@@ -270,7 +271,8 @@ class TestProCoDAParser(unittest.TestCase):
 
     def test_average_state(self):
         path = os.path.join(os.path.dirname(__file__), '.', 'data', '')
-        avgs = average_state(["6-19-2013", "6-20-2013"], 1, 28, "mL/s", path)
+        avgs = average_state(["6-19-2013", "6-20-2013"], 1, 28, "mL/s", path,
+                             extension=".xls")
         avgs = np.round(avgs, 5)
         self.assertSequenceEqual(
         avgs.tolist(),
@@ -289,7 +291,9 @@ class TestProCoDAParser(unittest.TestCase):
 
             return acc / num
 
-        avgs = perform_function_on_state(avg_with_units, ["6-19-2013", "6-20-2013"], 1, 28, "mL/s", path)
+        avgs = perform_function_on_state(avg_with_units,
+                                         ["6-19-2013", "6-20-2013"], 1, 28,
+                                         "mL/s", path, extension=".xls")
         avgs = np.round(avgs, 5)
         self.assertSequenceEqual(
         avgs.tolist(),
@@ -326,7 +330,8 @@ class TestProCoDAParser(unittest.TestCase):
             return acc / num
 
         output = write_calculations_to_csv(avg_with_units, 1, 28, path,
-                                           ["Average Conc (mg/L)"], out_path)
+                                           ["Average Conc (mg/L)"], out_path,
+                                           extension=".xls")
 
         self.assertSequenceEqual(["1", "2"], output['ID'].tolist())
         self.assertSequenceEqual(


### PR DESCRIPTION
The following changes have been made to `research.procoda_parser`:

- the default ProCoDA file extension is ".tsv" instead of ".xls"
- I have added functions for quickly plotting columns of data
- functions for getting columns of data and time deal with non-numeric entries (notes)

There will be negative coverage due to the two plotting functions, which are not tested with pytest.

@oliver-leung could this be a 0.2.0 release for adding new features?