### PR TITLE
Fixes to typos and procoda_parser parameters

### DIFF
--- a/aguaclara/core/units.py
+++ b/aguaclara/core/units.py
@@ -39,7 +39,7 @@ Units of Mass
 * ``u.ounce`` = ``u.oz``
 * ``u.pound`` = ``u.lb``
 * ``u.ton``
-* ``u.atomic_mass_unit` = ``u.amu``
+* ``u.atomic_mass_unit`` = ``u.amu``
 
 Units of Time
 -------------

--- a/aguaclara/research/procoda_parser.py
+++ b/aguaclara/research/procoda_parser.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 
 
-def column_of_data(path, start, column, end="-1", units=""):
+def column_of_data(path, start, column, end=-1, units=""):
     """This function extracts a column of data from a ProCoDA data file.
 
     Note: Column 0 is time. The first data column is column 1.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'aguaclara',
-    version = '0.1.11',
+    version = '0.1.12',
     description = (
         'An open-source Python package for designing and performing research '
         'on AguaClara water treatment plants.'

--- a/tests/core/test_physchem.py
+++ b/tests/core/test_physchem.py
@@ -8,19 +8,9 @@ Last modified: Tue Jun 4 2019
 By: Hannah Si
 """
 
-#Note: All answer values in this file should be checked against MathCad
-#before this file is released to the Master branch!
-
 from aguaclara.core.units import u
+from aguaclara.core import physchem as pc
 import unittest
-
-developing = False
-if developing:
-    import sys
-    sys.path.append("../../aguaclara/core")
-    import physchem as pc
-else:
-    from aguaclara.core import physchem as pc
 
 class AirTest(unittest.TestCase):
     """Test the air density function"""

--- a/tests/research/test_ProCoDA_Parser.py
+++ b/tests/research/test_ProCoDA_Parser.py
@@ -117,7 +117,7 @@ class TestProCoDAParser(unittest.TestCase):
         Extract the time column from a data file.
         '''''
         path = os.path.join(os.path.dirname(__file__), '.', 'data', 'example datalog.xls')
-        answer = column_of_time(path, 50, -1)
+        answer = column_of_time(path, 50)
         answer = np.round(answer, 5)
         self.assertSequenceEqual(
          answer.tolist(),
@@ -160,7 +160,7 @@ class TestProCoDAParser(unittest.TestCase):
          6.24987260e-03,   6.30772900e-03,   6.36560880e-03,
          6.42346920e-03,   6.48135320e-03,   6.53921020e-03,
          6.59709090e-03,   6.65494290e-03,   6.71281870e-03,
-         6.77069570e-03,   6.82855640e-03])*u.day, 5).tolist()
+         6.77069570e-03,   6.82855640e-03,   6.88642010e-03])*u.day, 5).tolist()
         )
 
 
@@ -169,7 +169,7 @@ class TestProCoDAParser(unittest.TestCase):
         Extract other columns of data and append units.
         '''''
         path = os.path.join(os.path.dirname(__file__), '.', 'data', 'example datalog.xls')
-        answer = column_of_data(path, 50, 1, -1, 'mg/L')
+        answer = column_of_data(path, 50, 1, units='mg/L')
         answer = np.round(answer, 5)
         self.assertSequenceEqual(
         answer.tolist(),
@@ -202,7 +202,7 @@ class TestProCoDAParser(unittest.TestCase):
          2.42190933,   2.36228228,   2.30094266,   2.24602866,
          2.19216943,   2.14143515,   2.10641694,   2.07170939,
          2.04412961,   2.0158174 ,   2.00059986,   1.98546684,
-         1.97646523,   1.96455812,   1.95887971])*u('mg/L'), 5).tolist()
+         1.97646523,   1.96455812,   1.95887971,   1.94987118])*u('mg/L'), 5).tolist()
         )
 
     def test_notes(self):

--- a/tests/research/test_floc_model.py
+++ b/tests/research/test_floc_model.py
@@ -4,14 +4,7 @@ Tests for the research package's floc_model functions
 
 import unittest
 from aguaclara.core.units import u
-
-developing = False
-if developing:
-    import sys
-    sys.path.append("../../aguaclara/research")
-    import floc_model as fm
-else:
-    import aguaclara.research.floc_model as fm
+import aguaclara.research.floc_model as fm
 
 
 class TestFlocModel(unittest.TestCase):

--- a/tests/research/test_peristaltic_pump.py
+++ b/tests/research/test_peristaltic_pump.py
@@ -4,14 +4,7 @@ Tests for the research package's tube_sizing module.
 
 import unittest
 from aguaclara.core.units import u
-
-developing = False
-if developing:
-    import sys
-    sys.path.append("../../aguaclara/research")
-    import peristaltic_pump as pp
-else:
-    import aguaclara.research.peristaltic_pump as pp
+import aguaclara.research.peristaltic_pump as pp
 
 
 class TestTubeSizing(unittest.TestCase):

--- a/tests/research/test_stock_qc.py
+++ b/tests/research/test_stock_qc.py
@@ -3,14 +3,7 @@ Tests for the research package's tube_sizing module.
 """
 import unittest
 from aguaclara.core.units import u
-
-developing = False
-if developing:
-    import sys
-    sys.path.append("../../aguaclara/research")
-    import stock_qc as stock_qc
-else:
-    import aguaclara.research.stock_qc as stock_qc
+import aguaclara.research.stock_qc as stock_qc
 
 C_reactor = stock_qc.Variable_C_Stock(1*u.mL/u.s, 2*u.mg/u.L, 0.4*u.mL/u.s)
 Q_reactor = stock_qc.Variable_Q_Stock(4.9*u.mL/u.s, 3.6*u.mg/u.L, 50*u.mg/u.L)


### PR DESCRIPTION
In `research.procoda_parser`'s `column_of_data` and `column_of_time`, the last row from which to extract data defaulted to -1. However, Pandas indexing is exclusive for the last index, so the functions defaulted to skipping the last row. 
The main change in this release is that the default includes all rows.