### PR TITLE
change matplotlib version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 # Ensure that this matches setup.py > setup() > install_requires
 [packages]
-matplotlib = "==3.0.3" # Supports Python 3.5
+matplotlib = "*" # Supports Python 3.5
 urllib3 = "*"
 pint = "==0.8.1"
 pandas = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 # Ensure that this matches setup.py > setup() > install_requires
 [packages]
-matplotlib = "*" # Supports Python 3.5
+matplotlib = "*"
 urllib3 = "*"
 pint = "==0.8.1"
 pandas = "*"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'aguaclara',
-    version = '0.1.15',
+    version = '0.1.16',
     description = (
         'An open-source Python package for designing and performing research '
         'on AguaClara water treatment plants.'


### PR DESCRIPTION
Before, when running !pip install aguaclara on a Google Colab tutorial, errors would result from implementing a different version of matplotlib. Now, the matplotlib version has been updated.