### PR TITLE
Fix order of parameters in headloss_kozeny and headloss_ergun

### DIFF
--- a/aguaclara/core/physchem.py
+++ b/aguaclara/core/physchem.py
@@ -1689,11 +1689,11 @@ def headloss_kozeny(ApproachVel, DiamMedia, Porosity, Length, Nu): #*,Diam,Vel
     #                       UserWarning)
     #         ApproachVel = Vel
 
-    ut.check_range([Length.magnitude, ">0", "Length"],
+    ut.check_range([ApproachVel.magnitude, ">0", "Velocity"],
                    [DiamMedia.magnitude, ">0", "Diam"],
-                   [ApproachVel.magnitude, ">0", "Velocity"],
-                   [Nu.magnitude, ">0", "Nu"],
-                   [Porosity, "0-1", "Porosity"])
+                   [Porosity, "0-1", "Porosity"],
+                   [Length.magnitude, ">0", "Length"],
+                   [Nu.magnitude, ">0", "Nu"])
     return (con.K_KOZENY * Length * Nu
             / u.gravity * (1-Porosity)**2
             / Porosity**3 * 36 * ApproachVel

--- a/aguaclara/core/physchem.py
+++ b/aguaclara/core/physchem.py
@@ -1650,47 +1650,44 @@ def flow_weir_rect(Height, Width):
 
 
 @ut.list_handler()
-def headloss_kozeny(Length, DiamMedia=None, ApproachVel=None, Porosity=None, Nu=None, *, Diam=None, Vel=None):
+def headloss_kozeny(ApproachVel, DiamMedia, Porosity, Length, Nu): #*,Diam,Vel
     """Return the Carman Kozeny sand bed head loss.
 
-    :param Length: height of bed
-    :type Length: u.m
-    :param DiamMedia: diameter of sand particle
-    :type DiamMedia: u.m
     :param ApproachVel: superficial velocity
     :type ApproachVel: u.m/u.s
+    :param DiamMedia: diameter of sand particle
+    :type DiamMedia: u.m
     :param Porosity: porosity of bed
     :type Porosity: u.dimensionless or unitless
+    :param Length: height of bed
+    :type Length: u.m
     :param Nu: kinematic viscosity of fluid
     :type Nu: u.m**2/u.s
-
-    :param Diam: deprecated; use DiamMedia instead
-    :param Vel: deprecated, use ApproachVel instead
 
     :return: head loss in sand bed
     :rtype: u.m
     """
-    if DiamMedia is not None and Diam is not None:
-        raise TypeError("headloss_kozeny received both DiamMedia and Diam")
-    elif DiamMedia is None and Diam is None:
-        raise TypeError("headloss_kozeny missing DiamMedia argument")
-    elif ApproachVel is not None and Vel is not None:
-        raise TypeError("headloss_kozeny received both ApproachVel and Vel")
-    elif ApproachVel is None and Vel is None:
-        raise TypeError("headloss_kozeny missing ApproachVel argument")
-    elif Porosity is None:
-        raise TypeError("headloss_kozeny missing Porosity argument")
-    elif Nu is None:
-        raise TypeError("headloss_kozeny missing Nu argument")
-    else:
-        if Diam is not None:
-            warnings.warn("Diam is deprecated; use DiamMedia instead.",
-                          UserWarning)
-            DiamMedia = Diam
-        if Vel is not None:
-            warnings.warn("Vel is deprecated; use ApproachVel instead.",
-                          UserWarning)
-            ApproachVel = Vel
+    # if DiamMedia is not None and Diam is not None:
+    #     raise TypeError("headloss_kozeny received both DiamMedia and Diam")
+    # elif DiamMedia is None and Diam is None:
+    #     raise TypeError("headloss_kozeny missing DiamMedia argument")
+    # elif ApproachVel is not None and Vel is not None:
+    #     raise TypeError("headloss_kozeny received both ApproachVel and Vel")
+    # elif ApproachVel is None and Vel is None:
+    #     raise TypeError("headloss_kozeny missing ApproachVel argument")
+    # elif Porosity is None:
+    #     raise TypeError("headloss_kozeny missing Porosity argument")
+    # elif Nu is None:
+    #     raise TypeError("headloss_kozeny missing Nu argument")
+    # else:
+    #     if Diam is not None:
+    #         warnings.warn("Diam is deprecated; use DiamMedia instead.",
+    #                       UserWarning)
+    #         DiamMedia = Diam
+    #     if Vel is not None:
+    #         warnings.warn("Vel is deprecated; use ApproachVel instead.",
+    #                       UserWarning)
+    #         ApproachVel = Vel
 
     ut.check_range([Length.magnitude, ">0", "Length"],
                    [DiamMedia.magnitude, ">0", "Diam"],
@@ -1748,19 +1745,19 @@ def fric_ergun(ApproachVel, DiamMedia, Temperature, Porosity):
 
 
 @ut.list_handler()
-def headloss_ergun(ApproachVel, DiamMedia, Temperature, Porosity, Length):
+def headloss_ergun(ApproachVel, DiamMedia, Porosity, Length, Temperature):
     """Return the frictional head loss for flow through porous media.
 
     :param ApproachVel: superficial fluid velocity (VelSuperficial?)
     :type ApproachVel: u.m/u.s
     :param DiamMedia: particle diameter
     :type DiamMedia: u.m
-    :param Temperature: temperature of porous medium
-    :type Temperature: u.degK
     :param Porosity: porosity of porous medium
     :type Porosity: u.dimensionless or unitless
     :param Length: length of pipe or duct
     :type Length: u.m
+    :param Temperature: temperature of porous medium
+    :type Temperature: u.degK
 
     :return: frictional head loss for flow through porous media
     :rtype: u.m

--- a/tests/core/test_physchem.py
+++ b/tests/core/test_physchem.py
@@ -949,17 +949,16 @@ class WeirFuncsTest(QuantityTest):
 class PorousMediaFuncsTest(QuantityTest):
     def test_headloss_kozeny(self):
         """headloss_kozeny should return known value for known input."""
-        self.assertAlmostEqualQuantity(pc.headloss_kozeny(1 * u.m, 1.4 * u.m, 0.5 * u.m/u.s, 0.625, 0.8 * u.m**2/u.s),
-                                       2.1576362645214617 * u.m)
+        self.assertAlmostEqualQuantity(pc.headloss_kozeny(0.5 * u.m/u.s, 1.4 * u.m, 0.625, 1 * u.m, 0.8 * u.m**2/u.s), 2.1576362645214617 * u.m)
 
     def test_headloss_kozeny_range(self):
         """headloss_kozeny should raise errors when inputs are out of bounds."""
-        checks = ((0 * u.m, 1 * u.m, 1 * u.m/u.s, 1, 1 * u.m**2/u.s),
-                  (1 * u.m, 0 * u.m, 1 * u.m/u.s, 1, 1 * u.m**2/u.s),
-                  (1 * u.m, 1 * u.m, 0 * u.m/u.s, 1, 1 * u.m**2/u.s),
-                  (1 * u.m, 1 * u.m, 1 * u.m/u.s, 1, 0 * u.m**2/u.s),
-                  (1 * u.m, 1 * u.m, 1 * u.m/u.s, -1, 1 * u.m**2/u.s),
-                  (1 * u.m, 1 * u.m, 1 * u.m/u.s, 2, 1 * u.m**2/u.s))
+        checks = ((1 * u.m/u.s, 1 * u.m, 1, 0 * u.m, 1 * u.m**2/u.s),
+                  (1 * u.m/u.s, 0 * u.m, 1, 1 * u.m, 1 * u.m**2/u.s),
+                  (0 * u.m/u.s, 1 * u.m, 1, 1 * u.m, 1 * u.m**2/u.s),
+                  (1 * u.m/u.s, 1 * u.m, 1, 1 * u.m, 0 * u.m**2/u.s),
+                  (1 * u.m/u.s, 1 * u.m, -1, 1 * u.m, 1 * u.m**2/u.s),
+                  (1 * u.m/u.s, 1 * u.m, 2, 1 * u.m, 1 * u.m**2/u.s))
         for i in checks:
             with self.subTest(i=i):
                 self.assertRaises(ValueError, pc.headloss_kozeny, *i)
@@ -982,7 +981,7 @@ class PorousMediaFuncsTest(QuantityTest):
                                        5.6505850237 * u.dimensionless)
 
     def test_headloss_ergun(self):
-        self.assertAlmostEqualQuantity(pc.headloss_ergun(0.1 * u.m/u.s, 10**-3 * u.m, 298 * u.degK, 0.2, 4 * u.m),
+        self.assertAlmostEqualQuantity(pc.headloss_ergun(0.1 * u.m/u.s, 10**-3 * u.m, 0.2, 4 * u.m, 298 * u.degK),
                                        1152.39863230 * u.m)
 
     def test_g_cs_ergun(self):


### PR DESCRIPTION
- Changed the parameters of headloss_kozeny to match the order of the parameters for headloss_ergun.
- Removed deprecated arguments and optional arguments from headloss_kozeny