### PR TITLE
Fix small bugs and add CDC documentation

### DIFF
--- a/aguaclara/core/physchem.py
+++ b/aguaclara/core/physchem.py
@@ -1680,6 +1680,9 @@ def re_ergun(ApproachVel, DiamMedia, Temperature, Porosity):
     ut.check_range([ApproachVel.magnitude, ">0", "ApproachVel"],
                    [DiamMedia.magnitude, ">0", "DiamMedia"],
                    [Porosity, "0-1", "Porosity"])
+    if Porosity == 1:
+        raise ValueError("Porosity is " + str(Porosity) + " must be great than\
+            or equal to 0 and less than 1")
     return (ApproachVel * DiamMedia /
             (viscosity_kinematic_water(Temperature)
              * (1 - Porosity))).to(u.dimensionless)

--- a/aguaclara/core/physchem.py
+++ b/aguaclara/core/physchem.py
@@ -113,7 +113,7 @@ def viscosity_dynamic_water(Temperature):
     :return: dynamic viscosity of water
     :rtype: u.kg/(u.m*u.s)
     """
-    ut.check_range([Temperature.magnitude, ">0", "Temperature in Kelvin"])
+    ut.check_range([Temperature.magnitude, ">=0", "Temperature in Kelvin"])
     return 2.414 * (10**-5) * u.kg/(u.m*u.s) * 10**(247.8*u.degK /
                                                     (Temperature - 140*u.degK))
 
@@ -139,7 +139,7 @@ def density_water(Temperature=None, *, temp=None):
                       UserWarning)
         Temperature = temp
 
-    ut.check_range([Temperature.magnitude, ">0", "Temperature in Kelvin"])
+    ut.check_range([Temperature.magnitude, ">=0", "Temperature in Kelvin"])
     rhointerpolated = interpolate.CubicSpline(WATER_DENSITY_TABLE[0],
                                               WATER_DENSITY_TABLE[1])
     Temperature = Temperature.to(u.degK).magnitude
@@ -168,7 +168,7 @@ def viscosity_kinematic_water(Temperature):
     :return: kinematic viscosity of water
     :rtype: u.m**2/u.s
     """
-    ut.check_range([Temperature.magnitude, ">0", "Temperature in Kelvin"])
+    ut.check_range([Temperature.magnitude, ">=0", "Temperature in Kelvin"])
     return (viscosity_dynamic_water(Temperature) / density_water(Temperature))
 
 ####################### Hydraulic Radius #######################

--- a/aguaclara/core/utility.py
+++ b/aguaclara/core/utility.py
@@ -166,18 +166,26 @@ def floor_nearest(x, array):
         - ``x``: Value to compare
         - ``array (numpy.array)``: Array to search
     """
-    i = np.argmax(array >= x) - 1
-    return array[i]
+    sorted_array = np.sort(array)[::-1]  # [::-1] syntax reverses array
+    if x < sorted_array[-1]:
+        raise ValueError(str(x) + " is smaller than all values in the array.")
+    else:
+        i = np.argmax(sorted_array <= x)
+        return sorted_array[i]
 
 def ceil_nearest(x, array):
-    """Get the nearest element of a NumPy array less than or equal to a value.
+    """Get the nearest element of a NumPy array greater than or equal to a value.
 
     Args:
         - ``x``: Value to compare
         - ``array (numpy.array)``: Array to search
     """
-    i = np.argmax(array >= x)
-    return array[i]
+    sorted_array = np.sort(array)
+    if x > sorted_array[-1]:
+        raise ValueError(str(x) + " is larger than all values in the array.")
+    else:
+        i = np.argmax(sorted_array >= x)
+        return sorted_array[i]
 
 def _minmax(*args, func=np.max):
     """Get the minuimum/maximum value of some Pint quantities with units.

--- a/aguaclara/design/cdc.py
+++ b/aguaclara/design/cdc.py
@@ -125,12 +125,14 @@ class CDC(Component):
 
     @property
     def coag_q_max_est(self):
+        """"""
         coag_q_max_est = self.q * self.coag_dose_conc_max / \
             self.coag_stock_conc_est
         return coag_q_max_est
 
     @property
     def coag_stock_vol(self):
+        """The volume of the coagulant stock."""
         coag_stock_vol = ut.ceil_nearest(
                 self.coag_stock_min_est_time * self.train_n *
                     self.coag_q_max_est,
@@ -140,6 +142,7 @@ class CDC(Component):
 
     @property
     def coag_sack_n(self):
+        """ """
         coag_sack_n = round(
                 (self.coag_stock_vol * self.coag_stock_conc_est /
                 self.coag_sack_mass).to_base_units()
@@ -148,21 +151,25 @@ class CDC(Component):
 
     @property
     def coag_stock_conc(self):
+        """The concentration of the coagulant stock."""
         coag_stock_conc = self.coag_sack_n * self.coag_sack_mass / \
             self.coag_stock_vol
         return coag_stock_conc
 
     @property
     def coag_q_max(self):
+        """The maximum permissible flow rate of the coagulant stock."""
         coag_q_max = self.q * self.coag_dose_conc_max / self.coag_stock_conc
         return coag_q_max.to(u.L / u.s)
 
     @property
     def coag_stock_time_min(self):
+        """ """
         return self.coag_stock_vol / (self.train_n * self.coag_q_max)
 
     @property
     def coag_stock_nu(self):
+        """The kinematic viscosity of the coagulant stock."""
         return self._coag_nu(self.coag_stock_conc, self.coag_type)
 #==============================================================================
 # Small-diameter Tube Design
@@ -176,12 +183,14 @@ class CDC(Component):
 
     @property
     def coag_tubes_active_n(self):
+        """The number of active coagulant tubes."""
         coag_tubes_active_n = \
             np.ceil((self.coag_q_max / self._coag_tube_q_max).to_base_units())
         return coag_tubes_active_n
 
     @property
     def coag_tubes_n(self):
+        """ """
         coag_tubes_n = self.coag_tubes_active_n + 1
         return coag_tubes_n
 
@@ -193,6 +202,7 @@ class CDC(Component):
 
     @property
     def coag_tube_l(self):
+        """ """
         coag_tube_l = (
                 self.hl * con.GRAVITY * np.pi * self.coag_tube_id ** 4 /
                 (128 * self.coag_stock_nu * self.coag_tube_operating_q_max)
@@ -204,12 +214,14 @@ class CDC(Component):
 
     @property
     def coag_tank_r(self):
+        """The radius of the coagulant stock tank."""
         index = np.where(self.chem_tank_vol_supplier == self.coag_stock_vol)
         coag_tank_r = self.chem_tank_dimensions_supplier[0][index] / 2
         return coag_tank_r
 
     @property
     def coag_tank_h(self):
+        """The height of the coagulant stock tank."""
         index = np.where(self.chem_tank_vol_supplier == self.coag_stock_vol)
         coag_tank_h = self.chem_tank_dimensions_supplier[1][index]
         return coag_tank_h

--- a/aguaclara/design/cdc.py
+++ b/aguaclara/design/cdc.py
@@ -13,6 +13,7 @@ import aguaclara.core.utility as ut
 from aguaclara.core.units import u
 import aguaclara.core.constants as con
 from aguaclara.design.component import Component
+import warnings
 
 import numpy as np
 
@@ -48,8 +49,9 @@ class CDC(Component):
 
         super().__init__(**kwargs)
 
-    def _alum_nu(self, coag_conc):
-        """Return the dynamic viscosity of water at a given temperature.
+    def alum_nu(self, coag_conc):
+        """
+        Return the dynamic viscosity of water at a given temperature.
 
         If given units, the function will automatically convert to Kelvin.
         If not given units, the function will assume Kelvin.
@@ -61,8 +63,19 @@ class CDC(Component):
             (1 + (4.255 * 10 ** -6) * coag_conc.magnitude ** 2.289) * \
             pc.viscosity_kinematic_water(self.temp)
         return alum_nu
-
-    def _pacl_nu(self, coag_conc):
+    
+    def _alum_nu(self, coag_conc):
+        """
+        .. deprecated::
+            `_alum_nu` is deprecated; use `alum_nu` instead.
+        """
+        # Deprecation added December 2020
+        warnings.warn('_alum_nu is deprecated; use alum_nu instead.',
+                  UserWarning)
+    
+        return self.alum_nu(coag_conc)
+        
+    def pacl_nu(self, coag_conc):
         """Return the dynamic viscosity of water at a given temperature.
 
         If given units, the function will automatically convert to Kelvin.
@@ -76,16 +89,38 @@ class CDC(Component):
             pc.viscosity_kinematic_water(self.temp)
         return pacl_nu
 
+    def _pacl_nu(self, coag_conc):
+        """
+        .. deprecated::
+            `_pacl_nu` is deprecated; use `pacl_nu` instead.
+        """
+        # Deprecation added December 2020
+        warnings.warn('_pacl_nu is deprecated; use pacl_nu instead.',
+                  UserWarning)
+    
+        return self.pacl_nu(coag_conc)
+        
     def _coag_nu(self, coag_conc, coag_type):
+        """
+        .. deprecated::
+            `_coag_nu` is deprecated; use `coag_nu` instead.
+        """
+        # Deprecation added December 2020
+        warnings.warn('_coag_nu is deprecated; use coag_nu instead.',
+                  UserWarning)
+    
+        return coag_nu(coag_conc, coag_type)
+       
+    def coag_nu(self, coag_conc, coag_type):
         """Return the dynamic viscosity of water at a given temperature.
 
         If given units, the function will automatically convert to Kelvin.
         If not given units, the function will assume Kelvin.
         """
         if coag_type.lower() == 'alum':
-            coag_nu = self._alum_nu(coag_conc)
+            coag_nu = self.alum_nu(coag_conc)
         elif coag_type.lower() == 'pacl':
-            coag_nu = self._pacl_nu(coag_conc)
+            coag_nu = self.pacl_nu(coag_conc)
         return coag_nu
 
     @property

--- a/aguaclara/design/cdc.py
+++ b/aguaclara/design/cdc.py
@@ -6,7 +6,7 @@ Example:
     >>> from aguaclara.design.cdc import *
     >>> cdc = CDC(q = 20 * u.L/u.s, coag_type = 'pacl')
     >>> cdc.coag_stock_vol
-    208.198 liter
+    <Quantity(2500.0, 'liter')>
 """
 import aguaclara.core.physchem as pc
 import aguaclara.core.utility as ut
@@ -29,7 +29,7 @@ class CDC(Component):
         if self.coag_type.lower() not in ['pacl', 'alum']:
             raise ValueError('coag_type must be either PACl or Alum.')
 
-        self.coag_dose_conc_max=2 * u.g / u.L #What should this default to? -Oliver L., 6 Jun 19
+        self.coag_dose_conc_max=100 * u.mg / u.L
         self.coag_stock_conc_est=150 * u.g / u.L
         self.coag_stock_min_est_time=1 * u.day
         self.chem_tank_vol_supplier=[208.198, 450, 600, 750, 1100, 2500] * u.L
@@ -125,7 +125,7 @@ class CDC(Component):
 
     @property
     def coag_q_max_est(self):
-        """"""
+        """The estimated maximum permissible flow rate of the coagulant stock."""
         coag_q_max_est = self.q * self.coag_dose_conc_max / \
             self.coag_stock_conc_est
         return coag_q_max_est
@@ -142,7 +142,7 @@ class CDC(Component):
 
     @property
     def coag_sack_n(self):
-        """ """
+        """The number of sacks of coagulant used to make the coagulant stock."""
         coag_sack_n = round(
                 (self.coag_stock_vol * self.coag_stock_conc_est /
                 self.coag_sack_mass).to_base_units()
@@ -164,7 +164,7 @@ class CDC(Component):
 
     @property
     def coag_stock_time_min(self):
-        """ """
+        """The minimum amount of time that the coagulant stock will last."""
         return self.coag_stock_vol / (self.train_n * self.coag_q_max)
 
     @property
@@ -183,14 +183,14 @@ class CDC(Component):
 
     @property
     def coag_tubes_active_n(self):
-        """The number of active coagulant tubes."""
+        """The number of coagulant tubes in use."""
         coag_tubes_active_n = \
             np.ceil((self.coag_q_max / self._coag_tube_q_max).to_base_units())
         return coag_tubes_active_n
 
     @property
     def coag_tubes_n(self):
-        """ """
+        """The number of coagulant tubes in use, plus a spare tube for maintenance."""
         coag_tubes_n = self.coag_tubes_active_n + 1
         return coag_tubes_n
 
@@ -202,7 +202,7 @@ class CDC(Component):
 
     @property
     def coag_tube_l(self):
-        """ """
+        """The length of a coagulant tube."""
         coag_tube_l = (
                 self.hl * con.GRAVITY * np.pi * self.coag_tube_id ** 4 /
                 (128 * self.coag_stock_nu * self.coag_tube_operating_q_max)

--- a/aguaclara/design/cdc.py
+++ b/aguaclara/design/cdc.py
@@ -4,7 +4,7 @@ dose the correct amount of coagulant and chlorine into the entrance tank.
 
 Example:
     >>> from aguaclara.design.cdc import *
-    >>> cdc = CDC(q = 20 * L/s, coag_type = 'pacl')
+    >>> cdc = CDC(q = 20 * u.L/u.s, coag_type = 'pacl')
     >>> cdc.coag_stock_vol
     208.198 liter
 """

--- a/aguaclara/design/cdc.py
+++ b/aguaclara/design/cdc.py
@@ -11,7 +11,6 @@ Example:
 import aguaclara.core.physchem as pc
 import aguaclara.core.utility as ut
 from aguaclara.core.units import u
-import aguaclara.core.constants as con
 from aguaclara.design.component import Component
 import warnings
 
@@ -24,13 +23,14 @@ class CDC(Component):
         - ``q (float * u.L / u.s)``: Flow rate (required)
     """
     def __init__(self, **kwargs):
-        self.hl = 20 * u.cm,
+        self.hl = 20 * u.cm
         self.coag_type='pacl'
         if self.coag_type.lower() not in ['pacl', 'alum']:
             raise ValueError('coag_type must be either PACl or Alum.')
 
         self.coag_dose_conc_max=100 * u.mg / u.L
-        self.coag_stock_conc_est=150 * u.g / u.L
+        self.coag_stock_conc=150 * u.g / u.L
+        self.coag_stock_conc_est=150 * u.g / u.L # Deprecated since January 2021
         self.coag_stock_min_est_time=1 * u.day
         self.chem_tank_vol_supplier=[208.198, 450, 600, 750, 1100, 2500] * u.L
         self.chem_tank_dimensions_supplier=[
@@ -69,7 +69,7 @@ class CDC(Component):
         .. deprecated::
             `_alum_nu` is deprecated; use `alum_nu` instead.
         """
-        # Deprecation added December 2020
+        # Deprecated since January 2021
         warnings.warn('_alum_nu is deprecated; use alum_nu instead.',
                   UserWarning)
     
@@ -81,8 +81,8 @@ class CDC(Component):
         If given units, the function will automatically convert to Kelvin.
         If not given units, the function will assume Kelvin.
         This function assumes that the temperature dependence can be explained
-        based on the effect on water and that there is no confounding effect from
-        the coagulant.
+        based on the effect on water and that there is no confounding effect 
+        from the coagulant.
         """
         pacl_nu = \
             (1 + (2.383 * 10 ** -5) * (coag_conc).magnitude ** 1.893) * \
@@ -94,7 +94,7 @@ class CDC(Component):
         .. deprecated::
             `_pacl_nu` is deprecated; use `pacl_nu` instead.
         """
-        # Deprecation added December 2020
+        # Deprecated since January 2021
         warnings.warn('_pacl_nu is deprecated; use pacl_nu instead.',
                   UserWarning)
     
@@ -105,11 +105,11 @@ class CDC(Component):
         .. deprecated::
             `_coag_nu` is deprecated; use `coag_nu` instead.
         """
-        # Deprecation added December 2020
+        # Deprecated since January 2021
         warnings.warn('_coag_nu is deprecated; use coag_nu instead.',
                   UserWarning)
     
-        return coag_nu(coag_conc, coag_type)
+        return self.coag_nu(coag_conc, coag_type)
        
     def coag_nu(self, coag_conc, coag_type):
         """Return the dynamic viscosity of water at a given temperature.
@@ -125,42 +125,59 @@ class CDC(Component):
 
     @property
     def coag_q_max_est(self):
-        """The estimated maximum permissible flow rate of the coagulant stock."""
+        """The estimated maximum permissible flow rate of the coagulant stock,
+        based on a whole number of sacks of coagulant used.
+
+        .. deprecated::
+            `coag_q_max_est` is deprecated; use `coag_q_max` instead, which is
+            based on the exact user-defined coagulant stock concentration, 
+            `coag_stock_conc`.
+        """
+        # Deprecated since January 2021
+        warnings.warn('coag_q_max_est is deprecated; use coag_q_max instead,\
+            which is based on the exact user-defined coagulant stock \
+            concentration, coag_stock_conc.', UserWarning)
+        
         coag_q_max_est = self.q * self.coag_dose_conc_max / \
             self.coag_stock_conc_est
         return coag_q_max_est
-
-    @property
-    def coag_stock_vol(self):
-        """The volume of the coagulant stock."""
-        coag_stock_vol = ut.ceil_nearest(
-                self.coag_stock_min_est_time * self.train_n *
-                    self.coag_q_max_est,
-                self.chem_tank_vol_supplier
-            )
-        return coag_stock_vol
-
-    @property
-    def coag_sack_n(self):
-        """The number of sacks of coagulant used to make the coagulant stock."""
-        coag_sack_n = round(
-                (self.coag_stock_vol * self.coag_stock_conc_est /
-                self.coag_sack_mass).to_base_units()
-            )
-        return coag_sack_n
-
-    @property
-    def coag_stock_conc(self):
-        """The concentration of the coagulant stock."""
-        coag_stock_conc = self.coag_sack_n * self.coag_sack_mass / \
-            self.coag_stock_vol
-        return coag_stock_conc
 
     @property
     def coag_q_max(self):
         """The maximum permissible flow rate of the coagulant stock."""
         coag_q_max = self.q * self.coag_dose_conc_max / self.coag_stock_conc
         return coag_q_max.to(u.L / u.s)
+
+    @property
+    def coag_stock_vol(self):
+        """The volume of the coagulant stock tank, based on available sizes
+        from the supplier.
+        """
+        coag_stock_vol = ut.ceil_nearest(
+                self.coag_stock_min_est_time * self.train_n *
+                    self.coag_q_max,
+                self.chem_tank_vol_supplier
+            )
+        return coag_stock_vol
+
+    @property
+    def coag_sack_n(self):
+        """The number of sacks of coagulant needed to make the coagulant stock,
+        rounded to the nearest whole number.
+        """
+        coag_sack_n = round(
+                (self.coag_stock_vol * self.coag_stock_conc /
+                self.coag_sack_mass).to_base_units()
+            )
+        return coag_sack_n
+
+    # Commented out January 2021
+    # @property
+    # def coag_stock_conc(self):
+    #     """The concentration of the coagulant stock."""
+    #     coag_stock_conc = self.coag_sack_n * self.coag_sack_mass / \
+    #         self.coag_stock_vol
+    #     return coag_stock_conc
 
     @property
     def coag_stock_time_min(self):
@@ -170,7 +187,7 @@ class CDC(Component):
     @property
     def coag_stock_nu(self):
         """The kinematic viscosity of the coagulant stock."""
-        return self._coag_nu(self.coag_stock_conc, self.coag_type)
+        return self.coag_nu(self.coag_stock_conc, self.coag_type)
 #==============================================================================
 # Small-diameter Tube Design
 #==============================================================================
@@ -178,8 +195,8 @@ class CDC(Component):
     def _coag_tube_q_max(self):
         """The maximum permissible flow through a coagulant tube."""
         coag_tube_q_max = ((np.pi * self.coag_tube_id ** 2)/4) * \
-            np.sqrt((2 * self.error_ratio * self.hl * con.GRAVITY)/self.tube_k)
-        return coag_tube_q_max
+            np.sqrt((2 * self.error_ratio * self.hl * u.gravity)/self.tube_k)
+        return coag_tube_q_max.to(u.L / u.s)
 
     @property
     def coag_tubes_active_n(self):
@@ -190,7 +207,9 @@ class CDC(Component):
 
     @property
     def coag_tubes_n(self):
-        """The number of coagulant tubes in use, plus a spare tube for maintenance."""
+        """The number of coagulant tubes in use, plus a spare tube for 
+        maintenance.
+        """
         coag_tubes_n = self.coag_tubes_active_n + 1
         return coag_tubes_n
 
@@ -204,7 +223,7 @@ class CDC(Component):
     def coag_tube_l(self):
         """The length of a coagulant tube."""
         coag_tube_l = (
-                self.hl * con.GRAVITY * np.pi * self.coag_tube_id ** 4 /
+                self.hl * u.gravity * np.pi * self.coag_tube_id ** 4 /
                 (128 * self.coag_stock_nu * self.coag_tube_operating_q_max)
             ) - (
                 8 * self.coag_tube_operating_q_max * self.tube_k /
@@ -214,16 +233,18 @@ class CDC(Component):
 
     @property
     def coag_tank_r(self):
-        """The radius of the coagulant stock tank."""
-        index = np.where(self.chem_tank_vol_supplier == self.coag_stock_vol)
-        coag_tank_r = self.chem_tank_dimensions_supplier[0][index] / 2
+        """The radius of the coagulant stock tank, based on available sizes
+        from the supplier."""
+        index = np.argmax(self.chem_tank_vol_supplier == self.coag_stock_vol)
+        coag_tank_r = self.chem_tank_dimensions_supplier[index][0] / 2
         return coag_tank_r
 
     @property
     def coag_tank_h(self):
-        """The height of the coagulant stock tank."""
-        index = np.where(self.chem_tank_vol_supplier == self.coag_stock_vol)
-        coag_tank_h = self.chem_tank_dimensions_supplier[1][index]
+        """The height of the coagulant stock tank, based on available sizes
+        from the supplier."""
+        index = np.argmax(self.chem_tank_vol_supplier == self.coag_stock_vol)
+        coag_tank_h = self.chem_tank_dimensions_supplier[index][1]
         return coag_tank_h
 
     def _DiamTubeAvail(self, en_tube_series = True):

--- a/aguaclara/design/pipeline.py
+++ b/aguaclara/design/pipeline.py
@@ -348,7 +348,7 @@ class Pipe(PipelineComponent):
     @property
     def headloss(self):
         """Return the total head loss from major and minor losses in a pipe."""
-        return pc.headloss_fric(
+        return pc.headloss_major_pipe(
                 self.q, self.id, self.l, self.nu, self.pipe_rough
             ).to(u.cm)
 
@@ -446,7 +446,7 @@ class Elbow(PipelineComponent):
     @property
     def headloss(self):
         """The headloss"""
-        return pc.elbow_minor_loss(self.q, self.id, self.k_minor).to(u.cm)
+        return pc.headloss_minor_elbow(self.q, self.id, self.k_minor).to(u.cm)
 
     def format_print(self):
         """The string representation for an Elbow Fitting."""
@@ -553,11 +553,11 @@ class Tee(PipelineComponent):
 
     def _headloss_left(self):
         """The headloss of the left outlet"""
-        return pc.elbow_minor_loss(self.q, self.id, self.left_k_minor).to(u.cm)
+        return pc.headloss_minor_elbow(self.q, self.id, self.left_k_minor).to(u.cm)
 
     def _headloss_right(self):
         """The headloss of the right outlet"""
-        return pc.elbow_minor_loss(self.q, self.id, self.right_k_minor).to(u.cm)
+        return pc.headloss_minor_elbow(self.q, self.id, self.right_k_minor).to(u.cm)
 
     @property
     def headloss(self):

--- a/aguaclara/research/environmental_processes_analysis.py
+++ b/aguaclara/research/environmental_processes_analysis.py
@@ -293,7 +293,7 @@ def E_CMFR_N(t, N):
     """
     return (N**N)/special.gamma(N) * (t**(N-1))*np.exp(-N*t)
 
-
+@ut.list_handler()
 def E_Advective_Dispersion(t, Pe):
     """Calculate a dimensionless measure of the output tracer concentration from
     a spike input to reactor with advection and dispersion.
@@ -312,11 +312,10 @@ def E_Advective_Dispersion(t, Pe):
     >>> round(E_Advective_Dispersion(0.5, 5), 7)
     0.4774864
     """
-    # replace any times at zero with a number VERY close to zero to avoid
-    # divide by zero errors
-    if isinstance(t, list):
-        t[t == 0] = 10**(-10)
-    return (Pe/(4*np.pi*t))**(0.5)*np.exp((-Pe*((1-t)**2))/(4*t))
+    if t == 0:
+        return 0
+    else:
+        return (Pe/(4*np.pi*t))**(0.5)*np.exp((-Pe*((1-t)**2))/(4*t))
 
 
 def Tracer_CMFR_N(t_seconds, t_bar, C_bar, N):

--- a/docs/source/design/cdc.rst
+++ b/docs/source/design/cdc.rst
@@ -1,0 +1,7 @@
+.. _design-cdc:
+
+Chemical Dose Controller
+========================
+
+.. automodule:: aguaclara.design.cdc
+    :members:

--- a/docs/source/design/design.rst
+++ b/docs/source/design/design.rst
@@ -4,6 +4,7 @@ Design
 .. toctree::
     :maxdepth: 2
     
+    cdc
     component
     ent_floc
     ent

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'aguaclara',
-    version = '0.2.9',
+    version = '0.2.10',
     description = (
         'An open-source Python package for designing and performing research '
         'on AguaClara water treatment plants.'

--- a/tests/core/test_physchem.py
+++ b/tests/core/test_physchem.py
@@ -972,10 +972,10 @@ class PorousMediaFuncsTest(QuantityTest):
                                        139.49692604 * u.dimensionless)
 
     def test_re_ergun_range(self):
-        checks = ((0 * u.m/u.s, 1 * u.m, 1 * u.degK, 1),
-                  (1 * u.m/u.s, 0 * u.m, 1 * u.degK, 1),
-                  (1 * u.m/u.s, 1 * u.m, 0 * u.degK, 1 * u.dimensionless),
-                  (1 * u.m/u.s, 1 * u.m, 1 * u.degK, -1 * u.dimensionless))
+        checks = ((0 * u.m/u.s, 1 * u.m, 1 * u.degK, .5),
+                  (1 * u.m/u.s, 0 * u.m, 1 * u.degK, .5),
+                  (1 * u.m/u.s, 1 * u.m, -1 * u.degK, .5 * u.dimensionless),
+                  (1 * u.m/u.s, 1 * u.m, 1 * u.degK, 1 * u.dimensionless))
         for i in checks:
             with self.subTest(i=i):
                 self.assertRaises(ValueError, pc.re_ergun, *i)

--- a/tests/core/test_utility.py
+++ b/tests/core/test_utility.py
@@ -28,6 +28,26 @@ class UtilityTest(QuantityTest):
         self.assertAlmostEqual(ut.round_sig_figs(0, 4), 0)
         self.assertAlmostEqual(ut.round_sig_figs(0 * u.m, 4), 0 * u.m)
 
+    def test_floor_nearest(self):
+        self.assertEqual(ut.floor_nearest(1, np.array([1, 1.5, 2])), 1)
+        self.assertEqual(ut.floor_nearest(1, np.array([0, 1, 1.5, 2])), 1)
+        self.assertEqual(ut.floor_nearest(1, np.array([0.5, 1.5, 2])), 0.5)
+        self.assertEqual(ut.floor_nearest(1, np.array([0, 2, 1.5, 0.5])), 0.5)
+        self.assertEqual(ut.floor_nearest(1, np.array([0.4, 0.2, 0.1, 0.5])), 0.5)
+
+    def test_floor_nearest_raises(self):
+        self.assertRaises(ValueError, ut.floor_nearest, x=1, array=np.array([1.5, 2, 2.5]))
+
+    def test_ceil_nearest(self):
+        self.assertEqual(ut.ceil_nearest(2, np.array([1, 1.5, 2])), 2)
+        self.assertEqual(ut.ceil_nearest(1.5, np.array([1, 1.5, 2])), 1.5)
+        self.assertEqual(ut.ceil_nearest(1.6, np.array([0.5, 1.5, 2])), 2)
+        self.assertEqual(ut.ceil_nearest(1.4, np.array([0, 2, 1.5, 0.5])), 1.5)
+        self.assertEqual(ut.ceil_nearest(0.4, np.array([0.8, 2, 1, 0.5])), 0.5)
+
+    def test_ceil_nearest_raises(self):
+        self.assertRaises(ValueError, ut.ceil_nearest, x=3, array=np.array([1.5, 2, 2.5]))
+
     def test_max(self):
         self.assertEqual(ut.max(2 * u.m, 4 * u.m),4 * u.m)
         self.assertEqual(ut.max(3 * u.m, 1 * u.m, 6 * u.m, 10 * u.m, 1.5 * u.m), 10 * u.m)

--- a/tests/design/test_cdc.py
+++ b/tests/design/test_cdc.py
@@ -1,0 +1,26 @@
+from aguaclara.design.cdc import CDC
+from aguaclara.core.units import u
+
+import pytest
+
+
+cdc_20 = CDC(q = 20.0 * u.L / u.s)
+cdc_60 = CDC(q = 60.0 * u.L / u.s)
+
+@pytest.mark.parametrize('actual, expected', [
+    (cdc_20.alum_nu(2 * u.g / u.L), 1.00357603e-06 * u.m**2 / u.s),
+	(cdc_60.alum_nu(2 * u.g / u.L), 1.00357603e-06 * u.m**2 / u.s),
+
+	(cdc_20.pacl_nu(2 * u.g / u.L), 1.00364398e-06 * u.m**2 / u.s),
+	(cdc_60.pacl_nu(2 * u.g / u.L), 1.00364398e-06 * u.m**2 / u.s),
+
+	(cdc_20.coag_nu(2 * u.g / u.L, "alum"), 1.00357603e-06 * u.m**2 / u.s),
+	(cdc_20.coag_nu(2 * u.g / u.L, "PACl"), 1.00364398e-06 * u.m**2 / u.s)
+])
+
+def test_cdc(actual, expected):
+	if (type(actual) == u.Quantity and type(expected) == u.Quantity):
+		assert actual.units == expected.units
+		assert actual.magnitude == pytest.approx(expected.magnitude)
+	else:
+		assert actual == pytest.approx(expected)

--- a/tests/design/test_cdc.py
+++ b/tests/design/test_cdc.py
@@ -3,9 +3,8 @@ from aguaclara.core.units import u
 
 import pytest
 
-
 cdc_20 = CDC(q = 20.0 * u.L / u.s)
-cdc_60 = CDC(q = 60.0 * u.L / u.s)
+cdc_60 = CDC(q = 60.0 * u.L / u.s, coag_stock_conc = 500 * u.g / u.L)
 
 @pytest.mark.parametrize('actual, expected', [
     (cdc_20.alum_nu(2 * u.g / u.L), 1.00357603e-06 * u.m**2 / u.s),
@@ -15,7 +14,40 @@ cdc_60 = CDC(q = 60.0 * u.L / u.s)
 	(cdc_60.pacl_nu(2 * u.g / u.L), 1.00364398e-06 * u.m**2 / u.s),
 
 	(cdc_20.coag_nu(2 * u.g / u.L, "alum"), 1.00357603e-06 * u.m**2 / u.s),
-	(cdc_20.coag_nu(2 * u.g / u.L, "PACl"), 1.00364398e-06 * u.m**2 / u.s)
+	(cdc_20.coag_nu(2 * u.g / u.L, "PACl"), 1.00364398e-06 * u.m**2 / u.s),
+
+	(cdc_20.coag_q_max, 0.01333333 * u.L / u.s),
+	(cdc_60.coag_q_max, 0.012 * u.L / u.s),
+
+	(cdc_20.coag_stock_vol, 2500 * u.L),
+	(cdc_60.coag_stock_vol, 1100 * u.L),
+
+	(cdc_20.coag_sack_n, 15),
+	(cdc_60.coag_sack_n, 22),
+
+	(cdc_20.coag_stock_time_min, 187500 * u.s),
+	(cdc_60.coag_stock_time_min, 91666.66666667 * u.s),
+
+	(cdc_20.coag_stock_nu, 1.31833437e-06 * u.m**2 / u.s),
+	(cdc_60.coag_stock_nu, 4.0783455e-06 * u.m**2 / u.s),
+
+	(cdc_20._coag_tube_q_max, 0.0035063291 * u.L / u.s),
+	(cdc_60._coag_tube_q_max, 0.0035063291 * u.L / u.s),
+
+	(cdc_20.coag_tubes_active_n, 4),
+	(cdc_60.coag_tubes_active_n, 4),
+
+	(cdc_20.coag_tube_operating_q_max, 0.003333333 * u.L / u.s),
+	(cdc_60.coag_tube_operating_q_max, 0.003 * u.L / u.s),
+
+	(cdc_20.coag_tube_l, 1.01256563 * u.m),
+	(cdc_60.coag_tube_l, 0.370547757 * u.m),
+
+	(cdc_20.coag_tank_r, 0.775 * u.m),
+	(cdc_60.coag_tank_r, 0.55 * u.m),
+
+	(cdc_20.coag_tank_h, 1.65 * u.m),
+	(cdc_60.coag_tank_h, 1.39 * u.m),
 ])
 
 def test_cdc(actual, expected):
@@ -24,3 +56,13 @@ def test_cdc(actual, expected):
 		assert actual.magnitude == pytest.approx(expected.magnitude)
 	else:
 		assert actual == pytest.approx(expected)
+
+@pytest.mark.parametrize('warning, func', [ 
+	(UserWarning, lambda: cdc_20._alum_nu(2 * u.g / u.L)),
+	(UserWarning, lambda: cdc_20._pacl_nu(2 * u.g / u.L)),
+	(UserWarning, lambda: cdc_20._coag_nu(2 * u.g / u.L, 'alum')),
+	(UserWarning, lambda: cdc_20.coag_q_max_est),
+])
+
+def test_cdc_warning(warning, func):
+	pytest.warns(warning, func)

--- a/tests/design/test_cdc.py
+++ b/tests/design/test_cdc.py
@@ -37,6 +37,9 @@ cdc_60 = CDC(q = 60.0 * u.L / u.s, coag_stock_conc = 500 * u.g / u.L)
 	(cdc_20.coag_tubes_active_n, 4),
 	(cdc_60.coag_tubes_active_n, 4),
 
+	(cdc_20.coag_tubes_n, 5),
+	(cdc_60.coag_tubes_n, 5),
+
 	(cdc_20.coag_tube_operating_q_max, 0.003333333 * u.L / u.s),
 	(cdc_60.coag_tube_operating_q_max, 0.003 * u.L / u.s),
 

--- a/tests/research/test_EPA.py
+++ b/tests/research/test_EPA.py
@@ -3,20 +3,36 @@ research tests.
 '''''
 
 import unittest
-from aguaclara.research.environmental_processes_analysis import *
+import aguaclara.research.environmental_processes_analysis as epa
+from aguaclara.core.units import u
+import numpy as np
 
 
 class TestEPA(unittest.TestCase):
     '''''
     Test research's Environmental_Processes_Analysis
     '''''
+    def assertAlmostEqualSequence(self, a, b, places=7):
+        for elt_a, elt_b in zip(a, b):
+            self.assertAlmostEqual(elt_a, elt_b, places)
 
     def test_Hplus_concentration_from_pH(self):
         '''''
         Test function that converts pH to molarity of H+
         '''''
-        answer = invpH(8.25)
-        self.assertEqual(answer, 5.623413251903491e-09*u.mol/u.L)
+        output = epa.invpH(8.25)
+        self.assertEqual(output, 5.623413251903491e-09*u.mol/u.L)
 
-        answer = invpH(10)
-        self.assertEqual(answer, 1e-10*u.mol/u.L)
+        output = epa.invpH(10)
+        self.assertEqual(output, 1e-10*u.mol/u.L)
+
+    def test_E_Advective_Dispersion(self):
+        output = epa.E_Advective_Dispersion(0.5, 5)
+        self.assertAlmostEqual(output, 0.4774864115)
+
+        output = epa.E_Advective_Dispersion(0, 5)
+        self.assertAlmostEqual(output, 0)
+
+        output = epa.E_Advective_Dispersion(np.array([0, 0.5, 1, 1.5, 2]), 5)
+        answer = np.array([0, 0.477486411, 0.630783130, 0.418173418, 0.238743205])
+        self.assertAlmostEqualSequence(output, answer)


### PR DESCRIPTION
This release:

* Resolves #251: The `cdc.py` module has been added to the Sphinx documentation, and its functions have been given descriptions. Also, estimated coagulant stock concentration and flow rate (`coag_stock_conc_est` and `coag_q_max_est`) have been deprecated and replaced with exact concentration and flow rate (`coag_stock_conc` and `coag_q_max`).
* Resolves #258: The `utilities.ceil_nearest` and `utilities.floor_nearest` functions did not work on unsorted arrays and returned the wrong output when values were out of range. They have been updated to sort inputted arrays and raise errors when values are out of range. Also, 
* Resolves #266: The `environmental_processes_analysis.E_Advective_Dispersion` function now returns 0 instead of NaN when t=0.
* Resolves #285: The `physchem` viscosity functions now accept temperatures of 0ºC.