### PR TITLE
Remove deprecated methods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,14 @@ jobs:
     - name: Run pytests and generate coverage report
       run: |
         pytest --cov=./ --cov-report=xml
-        codecov -t ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload coverage to Codecov
+      if: ${{ (matrix.python-version == 3.12) && (runner.os == 'Linux') }}
+      uses: codecov/codecov-action@v5
+      with:
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true
 
   test-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Run pytests and generate coverage report
       run: |
-        pytest --cov=./ --cov-report=xml tests
+        pytest --cov=./ --cov-report=xml
         codecov -t ${{ secrets.CODECOV_TOKEN }}
 
   test-docs:

--- a/aguaclara/core/utility.py
+++ b/aguaclara/core/utility.py
@@ -79,24 +79,6 @@ def round_sig_figs(num, figs=4):
     return num
 
 
-def round_sf(num, figs=4):
-    """Round a number to some amount of significant figures.
-
-    Args:
-        - ``num (float)``: Value to be rounded (optional units)
-        - ``figs (int)``: Number of significant digits to be rounded to
-          (recommended, defaults to 4)
-
-    Note: This function will be deprecated after 21 Dec 2019. Use
-    round_sig_figs instead.
-    """
-    warnings.warn(
-        "round_sf will be deprecated after 21 Dec 2019. Use " "round_sig_figs instead.",
-        FutureWarning,
-    )
-    round_sig_figs(num, figs=figs)
-
-
 @optional_units([0, 1], ["num", "step"])
 def _stepper(num, step=10, func=round):
     """Round a number to be a multiple of some step.
@@ -141,28 +123,6 @@ def ceil_step(num, step=10):
 def floor_step(num, step=10):
     """Like :func:`round_step`, but ``num`` is always rounded down."""
     return _stepper(num, step=step, func=floor)
-
-
-def stepceil_with_units(param, step, unit):
-    """Round a number up to be a multiple of some step.
-
-    Args:
-        - ``param (float)``: Value to be rounded (optional units)
-        - ``step (float)``: Factor to which ``param`` will be rounded
-        - ``unit (Quantity)``: units of ``step``
-
-    Note: this function will be deprecated after 21 Dec 2019. Use ceil_step
-    instead.
-    """
-    warnings.warn(
-        "stepceil_with_units will be deprecated after 21 Dec 2019. Use "
-        "ceil_step instead.",
-        FutureWarning,
-    )
-    counter = 0 * unit
-    while counter < param.to(unit):
-        counter += step * unit
-    return counter
 
 
 def floor_nearest(x, array):

--- a/aguaclara/core/utility.py
+++ b/aguaclara/core/utility.py
@@ -12,7 +12,6 @@ Example:
 from aguaclara.core.units import u
 import numpy as np
 from math import log10, floor, ceil
-import warnings
 import functools
 
 

--- a/aguaclara/design/cdc.py
+++ b/aguaclara/design/cdc.py
@@ -76,16 +76,6 @@ class CDC(Component):
         ) * pc.viscosity_kinematic_water(self.temp)
         return alum_nu
 
-    def _alum_nu(self, coag_conc):
-        """
-        .. deprecated::
-            `_alum_nu` is deprecated; use `alum_nu` instead.
-        """
-        # Deprecated since January 2021
-        warnings.warn("_alum_nu is deprecated; use alum_nu instead.", UserWarning)
-
-        return self.alum_nu(coag_conc)
-
     def pacl_nu(self, coag_conc):
         """Return the dynamic viscosity of water at a given temperature.
 
@@ -101,26 +91,6 @@ class CDC(Component):
             * (coag_conc / (u.kg / u.m**3)).to(u.dimensionless) ** 1.893
         ) * pc.viscosity_kinematic_water(self.temp)
         return pacl_nu
-
-    def _pacl_nu(self, coag_conc):
-        """
-        .. deprecated::
-            `_pacl_nu` is deprecated; use `pacl_nu` instead.
-        """
-        # Deprecated since January 2021
-        warnings.warn("_pacl_nu is deprecated; use pacl_nu instead.", UserWarning)
-
-        return self.pacl_nu(coag_conc)
-
-    def _coag_nu(self, coag_conc, coag_type):
-        """
-        .. deprecated::
-            `_coag_nu` is deprecated; use `coag_nu` instead.
-        """
-        # Deprecated since January 2021
-        warnings.warn("_coag_nu is deprecated; use coag_nu instead.", UserWarning)
-
-        return self.coag_nu(coag_conc, coag_type)
 
     def coag_nu(self, coag_conc, coag_type):
         """Return the dynamic viscosity of water at a given temperature.

--- a/aguaclara/research/floc_model.py
+++ b/aguaclara/research/floc_model.py
@@ -917,53 +917,6 @@ def diam_vel(EnergyDis, Temp, ConcAl, ConcClay, coag, material, DIM_FRACTAL):
     ).to(u.m)
 
 
-# @u.wraps(u.m, u.W/u.kg, False)
-@ut.list_handler()
-def diam_floc_max(epsMax):
-    """
-    .. deprecated:: 0.1.13
-        diam_floc_max is deprecated and will be removed after Dec 1 2019. The
-        underlying equation is under suspicion.
-
-    Return floc size as a function of energy dissipation rate.
-
-    Based on Ian Tse's work with floc size as a function of energy
-    dissipation rate. This is for the average energy dissipation rate
-    in a tube flocculator. It isn't clear how to convert this to the
-    turbulent flow case. Maybe the flocs are mostly experiencing viscous
-    shear. But that isn't clear. Some authors have made the case that
-    floc breakup is due to viscous effects. If that is the case, then
-    the results from the tube flocculator should be applicable to the
-    turbulent case. We will have to account for the temporal and spatial
-    variability in the turbulent energy dissipation rate. The factor of
-    95 μm is based on the assumption that the ratio of the max to
-    average energy dissipation rate for laminar flow is approximately 2.
-    """
-    # return (9.5 * 10**-5 * (1 / (epsMax)**(1/3))).to(u.m)
-    raise FutureWarning(
-        "diam_floc_max is deprecated and will be removed after Dec"
-        " 1 2019. The underlying equation is under suspicion."
-    )
-
-
-# @u.wraps(u.W/u.kg, u.m, False)
-@ut.list_handler()
-def ener_dis_diam_floc(Diam):
-    """
-    .. deprecated:: 0.1.13
-        ener_dis_diam_floc is deprecated and will be removed after Dec 1 2019.
-        The underlying equation is under suspicion.
-
-    Return max energy dissipation rate as a function of max floc diameter.
-    """
-    # return ((9.5 * 10**-5 / Diam) ** 3).to(u.W/u.kg)
-    raise FutureWarning(
-        "ener_dis_diam_floc is deprecated and will be removed"
-        " after Dec 1 2019. The underlying equation is under"
-        " suspicion."
-    )
-
-
 #####################################################################
 # Velocity gradient in tubing for lab scale laminar flow flocculators
 #####################################################################

--- a/docs/source/core/utility.rst
+++ b/docs/source/core/utility.rst
@@ -3,4 +3,3 @@ Utility
 
 .. automodule:: aguaclara.core.utility
     :members:
-    :exclude-members: stepceil_with_units

--- a/tests/design/test_cdc.py
+++ b/tests/design/test_cdc.py
@@ -6,6 +6,53 @@ import pytest
 cdc_20 = CDC(q=20.0 * u.L / u.s)
 cdc_60 = CDC(q=60.0 * u.L / u.s, coag_stock_conc=500 * u.g / u.L)
 
+@pytest.mark.parametrize('actual, expected', [
+    (cdc_20.alum_nu(2 * u.g / u.L), 1.00357603e-06 * u.m**2 / u.s),
+	(cdc_60.alum_nu(2 * u.g / u.L), 1.00357603e-06 * u.m**2 / u.s),
+
+	(cdc_20.pacl_nu(2 * u.g / u.L), 1.00364398e-06 * u.m**2 / u.s),
+	(cdc_60.pacl_nu(2 * u.g / u.L), 1.00364398e-06 * u.m**2 / u.s),
+
+	(cdc_20.coag_nu(2 * u.g / u.L, "alum"), 1.00357603e-06 * u.m**2 / u.s),
+	(cdc_20.coag_nu(2 * u.g / u.L, "PACl"), 1.00364398e-06 * u.m**2 / u.s),
+
+
+	(cdc_20.coag_q_max, 0.01333333 * u.L / u.s),
+	(cdc_60.coag_q_max, 0.012 * u.L / u.s),
+
+	(cdc_20.coag_stock_vol, 2500 * u.L),
+	(cdc_60.coag_stock_vol, 1100 * u.L),
+
+	(cdc_20.coag_sack_n, 15),
+	(cdc_60.coag_sack_n, 22),
+
+	(cdc_20.coag_stock_time_min, 187500 * u.s),
+	(cdc_60.coag_stock_time_min, 91666.66666667 * u.s),
+
+	(cdc_20.coag_stock_nu, 1.31833437e-06 * u.m**2 / u.s),
+	(cdc_60.coag_stock_nu, 4.0783455e-06 * u.m**2 / u.s),
+
+	(cdc_20._coag_tube_q_max, 0.0035063291 * u.L / u.s),
+	(cdc_60._coag_tube_q_max, 0.0035063291 * u.L / u.s),
+
+	(cdc_20.coag_tubes_active_n, 4),
+	(cdc_60.coag_tubes_active_n, 4),
+
+	(cdc_20.coag_tubes_n, 5),
+	(cdc_60.coag_tubes_n, 5),
+
+	(cdc_20.coag_tube_operating_q_max, 0.003333333 * u.L / u.s),
+	(cdc_60.coag_tube_operating_q_max, 0.003 * u.L / u.s),
+
+	(cdc_20.coag_tube_l, 1.01256563 * u.m),
+	(cdc_60.coag_tube_l, 0.370547757 * u.m),
+
+	(cdc_20.coag_tank_r, 0.775 * u.m),
+	(cdc_60.coag_tank_r, 0.55 * u.m),
+
+	(cdc_20.coag_tank_h, 1.65 * u.m),
+	(cdc_60.coag_tank_h, 1.39 * u.m),
+])
 
 @pytest.mark.parametrize(
     "actual, expected",

--- a/tests/design/test_cdc.py
+++ b/tests/design/test_cdc.py
@@ -61,16 +61,3 @@ def test_cdc(actual, expected):
         assert actual.magnitude == pytest.approx(expected.magnitude)
     else:
         assert actual == pytest.approx(expected)
-
-
-@pytest.mark.parametrize(
-    "warning, func",
-    [
-        (UserWarning, lambda: cdc_20._alum_nu(2 * u.g / u.L)),
-        (UserWarning, lambda: cdc_20._pacl_nu(2 * u.g / u.L)),
-        (UserWarning, lambda: cdc_20._coag_nu(2 * u.g / u.L, "alum")),
-        (UserWarning, lambda: cdc_20.coag_q_max_est),
-    ],
-)
-def test_cdc_warning(warning, func):
-    pytest.warns(warning, func)

--- a/tests/design/test_cdc.py
+++ b/tests/design/test_cdc.py
@@ -6,6 +6,7 @@ import pytest
 cdc_20 = CDC(q=20.0 * u.L / u.s)
 cdc_60 = CDC(q=60.0 * u.L / u.s, coag_stock_conc=500 * u.g / u.L)
 
+
 @pytest.mark.parametrize('actual, expected', [
     (cdc_20.alum_nu(2 * u.g / u.L), 1.00357603e-06 * u.m**2 / u.s),
 	(cdc_60.alum_nu(2 * u.g / u.L), 1.00357603e-06 * u.m**2 / u.s),
@@ -54,41 +55,6 @@ cdc_60 = CDC(q=60.0 * u.L / u.s, coag_stock_conc=500 * u.g / u.L)
 	(cdc_60.coag_tank_h, 1.39 * u.m),
 ])
 
-@pytest.mark.parametrize(
-    "actual, expected",
-    [
-        (cdc_20.alum_nu(2 * u.g / u.L), 1.00357603e-06 * u.m**2 / u.s),
-        (cdc_60.alum_nu(2 * u.g / u.L), 1.00357603e-06 * u.m**2 / u.s),
-        (cdc_20.pacl_nu(2 * u.g / u.L), 1.00364398e-06 * u.m**2 / u.s),
-        (cdc_60.pacl_nu(2 * u.g / u.L), 1.00364398e-06 * u.m**2 / u.s),
-        (cdc_20.coag_nu(2 * u.g / u.L, "alum"), 1.00357603e-06 * u.m**2 / u.s),
-        (cdc_20.coag_nu(2 * u.g / u.L, "PACl"), 1.00364398e-06 * u.m**2 / u.s),
-        (cdc_20.coag_q_max, 0.01333333 * u.L / u.s),
-        (cdc_60.coag_q_max, 0.012 * u.L / u.s),
-        (cdc_20.coag_stock_vol, 2500 * u.L),
-        (cdc_60.coag_stock_vol, 1100 * u.L),
-        (cdc_20.coag_sack_n, 15),
-        (cdc_60.coag_sack_n, 22),
-        (cdc_20.coag_stock_time_min, 187500 * u.s),
-        (cdc_60.coag_stock_time_min, 91666.66666667 * u.s),
-        (cdc_20.coag_stock_nu, 1.31833437e-06 * u.m**2 / u.s),
-        (cdc_60.coag_stock_nu, 4.0783455e-06 * u.m**2 / u.s),
-        (cdc_20._coag_tube_q_max, 0.0035063291 * u.L / u.s),
-        (cdc_60._coag_tube_q_max, 0.0035063291 * u.L / u.s),
-        (cdc_20.coag_tubes_active_n, 4),
-        (cdc_60.coag_tubes_active_n, 4),
-        (cdc_20.coag_tubes_n, 5),
-        (cdc_60.coag_tubes_n, 5),
-        (cdc_20.coag_tube_operating_q_max, 0.003333333 * u.L / u.s),
-        (cdc_60.coag_tube_operating_q_max, 0.003 * u.L / u.s),
-        (cdc_20.coag_tube_l, 1.01256563 * u.m),
-        (cdc_60.coag_tube_l, 0.370547757 * u.m),
-        (cdc_20.coag_tank_r, 0.775 * u.m),
-        (cdc_60.coag_tank_r, 0.55 * u.m),
-        (cdc_20.coag_tank_h, 1.65 * u.m),
-        (cdc_60.coag_tank_h, 1.39 * u.m),
-    ],
-)
 def test_cdc(actual, expected):
     if type(actual) == u.Quantity and type(expected) == u.Quantity:
         assert actual.units == expected.units

--- a/tests/research/test_floc_model.py
+++ b/tests/research/test_floc_model.py
@@ -418,18 +418,6 @@ class TestKolmogorovAndViscous(QuantityTest):
             10,
         )
 
-    def test_diam_floc_max(self):
-        self.assertRaisesRegex(
-            FutureWarning,
-            "diam_floc_max is deprecated and will be removed after Dec 1 2019. The underlying equation is under suspicion.",
-        )
-
-    def test_ener_dis_diam_floc(self):
-        self.assertRaisesRegex(
-            FutureWarning,
-            "ener_dis_diam_floc is deprecated and will be removed after Dec 1 2019. The underlying equation is under suspicion.",
-        )
-
 
 class TestVelocityGradient(QuantityTest):
 


### PR DESCRIPTION
Updated cdc.py
- Deleting deprecated methods in cdc.py(_alum_nu, _pacl_nu, _coag_nu, coag_q_max_est)

Updating test_cdc.py: 
- deleted test cases involving deprecated methods(_alum_nu, _pacl_nu, _coag_nu, coag_q_max_est)

Updating floc_model.py
- Deleting methods deprecated in Dec 2019

Updating test_floc_model.py
- Deleting methods deprecated in Dec 2019

Updating Utility.py:
- Deleting deprecated methods in Utility.py as they are no longer in use as of Dec 21 2019


