### PR TITLE
Update cdc.py

### DIFF
--- a/aguaclara/design/cdc.py
+++ b/aguaclara/design/cdc.py
@@ -1,7 +1,6 @@
 """The chemical dose controller (CDC) of an AguaClara plant uses the linear
 relation between flow rate and entrance tank water level (set by the LFOM) to
 dose the correct amount of coagulant and chlorine into the entrance tank.
-
 Example:
     >>> from aguaclara.design.cdc import *
     >>> cdc = CDC(q = 20 * u.L/u.s, coag_type = 'pacl')
@@ -18,7 +17,6 @@ import numpy as np
 
 class CDC(Component):
     """Design an AguaClara plant's chemical dose controller.
-
     Design Inputs:
         - ``q (float * u.L / u.s)``: Flow rate (required)
     """
@@ -30,7 +28,6 @@ class CDC(Component):
 
         self.coag_dose_conc_max=100 * u.mg / u.L
         self.coag_stock_conc=150 * u.g / u.L
-        self.coag_stock_conc_est=150 * u.g / u.L # Deprecated since January 2021
         self.coag_stock_min_est_time=1 * u.day
         self.chem_tank_vol_supplier=[208.198, 450, 600, 750, 1100, 2500] * u.L
         self.chem_tank_dimensions_supplier=[
@@ -52,7 +49,6 @@ class CDC(Component):
     def alum_nu(self, coag_conc):
         """
         Return the dynamic viscosity of water at a given temperature.
-
         If given units, the function will automatically convert to Kelvin.
         If not given units, the function will assume Kelvin.
         This function assumes that the temperature dependence can be explained
@@ -60,24 +56,12 @@ class CDC(Component):
         the coagulant.
         """
         alum_nu = \
-            (1 + (4.255 * 10 ** -6) * (coag_conc/(u.kg/u.m**3)).to(u.dimensionless) ** 2.289) * \
+            (1 + (4.255 * 10 ** -6) * coag_conc.magnitude ** 2.289) * \
             pc.viscosity_kinematic_water(self.temp)
         return alum_nu
 
-    def _alum_nu(self, coag_conc):
-        """
-        .. deprecated::
-            `_alum_nu` is deprecated; use `alum_nu` instead.
-        """
-        # Deprecated since January 2021
-        warnings.warn('_alum_nu is deprecated; use alum_nu instead.',
-                  UserWarning)
-
-        return self.alum_nu(coag_conc)
-
     def pacl_nu(self, coag_conc):
         """Return the dynamic viscosity of water at a given temperature.
-
         If given units, the function will automatically convert to Kelvin.
         If not given units, the function will assume Kelvin.
         This function assumes that the temperature dependence can be explained
@@ -85,35 +69,12 @@ class CDC(Component):
         from the coagulant.
         """
         pacl_nu = \
-            (1 + (2.383 * 10 ** -5) * (coag_conc/(u.kg/u.m**3)).to(u.dimensionless) ** 1.893) * \
+            (1 + (2.383 * 10 ** -5) * (coag_conc).magnitude ** 1.893) * \
             pc.viscosity_kinematic_water(self.temp)
         return pacl_nu
 
-    def _pacl_nu(self, coag_conc):
-        """
-        .. deprecated::
-            `_pacl_nu` is deprecated; use `pacl_nu` instead.
-        """
-        # Deprecated since January 2021
-        warnings.warn('_pacl_nu is deprecated; use pacl_nu instead.',
-                  UserWarning)
-
-        return self.pacl_nu(coag_conc)
-
-    def _coag_nu(self, coag_conc, coag_type):
-        """
-        .. deprecated::
-            `_coag_nu` is deprecated; use `coag_nu` instead.
-        """
-        # Deprecated since January 2021
-        warnings.warn('_coag_nu is deprecated; use coag_nu instead.',
-                  UserWarning)
-
-        return self.coag_nu(coag_conc, coag_type)
-
     def coag_nu(self, coag_conc, coag_type):
         """Return the dynamic viscosity of water at a given temperature.
-
         If given units, the function will automatically convert to Kelvin.
         If not given units, the function will assume Kelvin.
         """
@@ -127,7 +88,6 @@ class CDC(Component):
     def coag_q_max_est(self):
         """The estimated maximum permissible flow rate of the coagulant stock,
         based on a whole number of sacks of coagulant used.
-
         .. deprecated::
             `coag_q_max_est` is deprecated; use `coag_q_max` instead, which is
             based on the exact user-defined coagulant stock concentration,
@@ -195,8 +155,11 @@ class CDC(Component):
     def _coag_tube_q_max(self):
         """The maximum permissible flow through a coagulant tube."""
         coag_tube_q_max = ((np.pi * self.coag_tube_id ** 2)/4) * \
-            np.sqrt((2 * self.error_ratio * self.hl * u.gravity)/self.tube_k)
-        return coag_tube_q_max.to(u.L / u.s)
+            np.sqrt((2 * self.error_ratio * self.hl * con.GRAVITY)/self.tube_k)
+        re = pc.re_pipe(coag_tube_q_max,self.coag_tube_id,self._coag_nu)
+        if re >= pc.RE_TRANSITION_PIPE:
+            coag_tube_q_max = (pc.RE_TRANSITION_PIPE * np.pi * self.coag_tube_id* self._coag_nu)/4
+        return coag_tube_q_max
 
     @property
     def coag_tubes_active_n(self):


### PR DESCRIPTION
Issue #238 and #257

Added constraint for Reynold's Number to ensure that code doesn't allow for turbulent flows through the coagulant dosing tubes which violates the linear relationship between head loss and flow. The code would set the maximum flow through the tube to always be laminar. 

